### PR TITLE
Index accessors, clippy and safety fixes.

### DIFF
--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -99,6 +99,67 @@ macro_rules! bivec2s {
             pub fn layout() -> alloc::alloc::Layout {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
             }
+
+             #[inline]
+            pub fn as_slice(&self) -> &[$t] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts(self as *const $bn as *const $t, 1)
+                }
+            }
+
+
+            #[inline]
+            pub fn as_byte_slice(&self) -> &[u8] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts(self as *const $bn as *const u8, std::mem::size_of::<$t>())
+                }
+            }
+
+            #[inline]
+            pub fn as_mut_slice(&mut self) -> &mut [$t] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts_mut(self as *mut $bn as *mut $t, 1)
+                }
+            }
+
+            #[inline]
+            pub fn as_mut_byte_slice(&mut self) -> &mut [u8] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts_mut(self as *mut $bn as *mut u8, std::mem::size_of::<$t>())
+                }
+            }
+
+            /// Returns a constant unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub fn as_ptr(&self) -> *const $t {
+                self as *const $bn as *const $t
+            }
+
+            /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $bn as *mut $t
+            }
         }
 
         impl EqualsEps for $bn {
@@ -316,6 +377,67 @@ macro_rules! bivec3s {
             #[inline]
             pub fn layout() -> alloc::alloc::Layout {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
+            }
+
+             #[inline]
+            pub fn as_slice(&self) -> &[$t] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts(self as *const $bn as *const $t, 3)
+                }
+            }
+
+
+            #[inline]
+            pub fn as_byte_slice(&self) -> &[u8] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts(self as *const $bn as *const u8, 3 * std::mem::size_of::<$t>())
+                }
+            }
+
+            #[inline]
+            pub fn as_mut_slice(&mut self) -> &mut [$t] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts_mut(self as *mut $bn as *mut $t, 3)
+                }
+            }
+
+            #[inline]
+            pub fn as_mut_byte_slice(&mut self) -> &mut [u8] {
+                // This is safe because we are statically bounding our slices to the size of these
+                // vectors
+                unsafe {
+                    std::slice::from_raw_parts_mut(self as *mut $bn as *mut u8, 3 * std::mem::size_of::<$t>())
+                }
+            }
+
+            /// Returns a constant unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub fn as_ptr(&self) -> *const $t {
+                self as *const $bn as *const $t
+            }
+
+            /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $bn as *mut $t
             }
         }
 

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -134,6 +134,20 @@ macro_rules! mat2s {
                 Self::from(*comps)
             }
         }
+
+        impl Index<usize> for $n {
+            type Output = $vt;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                &self.cols[index]
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                &mut self.cols[index]
+            }
+        }
         )+
     }
 }
@@ -434,6 +448,20 @@ macro_rules! mat3s {
             #[inline]
             fn from(comps: &[$t; 9]) -> Self {
                 Self::from(*comps)
+            }
+        }
+
+        impl Index<usize> for $n {
+            type Output = $vt;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                &self.cols[index]
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                &mut self.cols[index]
             }
         }
         )+
@@ -800,6 +828,22 @@ macro_rules! mat4s {
                 Self::from(*comps)
             }
         }
+
+
+        impl Index<usize> for $n {
+            type Output = $vt;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                &self.cols[index]
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                &mut self.cols[index]
+            }
+        }
+
         )+
     }
 }

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -34,7 +34,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 4)
                 }
             }
 
@@ -43,7 +43,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 2)
+                    std::slice::from_raw_parts(self as *const $n as *const $vt, 2)
                 }
             }
 
@@ -52,7 +52,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 4 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 4 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -61,7 +61,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 4)
                 }
             }
 
@@ -70,7 +70,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 2)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $vt, 2)
                 }
             }
 
@@ -79,7 +79,7 @@ macro_rules! mat2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 4 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 4 * std::mem::size_of::<$t>())
                 }
             }
         }
@@ -310,7 +310,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 9)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 9)
                 }
             }
 
@@ -319,7 +319,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 3)
+                    std::slice::from_raw_parts(self as *const $n as *const $vt, 3)
                 }
             }
 
@@ -328,7 +328,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 9 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 9 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -337,7 +337,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 9)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 9)
                 }
             }
 
@@ -346,7 +346,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 3)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $vt, 3)
                 }
             }
 
@@ -355,7 +355,7 @@ macro_rules! mat3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 9 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 9 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -368,9 +368,7 @@ macro_rules! mat3s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
@@ -381,10 +379,8 @@ macro_rules! mat3s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_mut_ptr(&self) -> *mut $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
             }
         }
 
@@ -674,7 +670,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 16)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 16)
                 }
             }
 
@@ -683,7 +679,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts(self as *const $n as *const $vt, 4)
                 }
             }
 
@@ -692,7 +688,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 16 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 16 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -701,7 +697,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 16)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 16)
                 }
             }
 
@@ -710,7 +706,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $vt, 4)
                 }
             }
 
@@ -719,7 +715,7 @@ macro_rules! mat4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 16 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 16 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -732,9 +728,7 @@ macro_rules! mat4s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
@@ -745,10 +739,8 @@ macro_rules! mat4s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_mut_ptr(&self) -> *mut $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
             }
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -240,16 +240,17 @@ macro_rules! vec2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 2)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 2)
                 }
             }
+
 
             #[inline]
             pub fn as_byte_slice(&self) -> &[u8] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 2 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 2 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -258,7 +259,7 @@ macro_rules! vec2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 2)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 2)
                 }
             }
 
@@ -267,7 +268,7 @@ macro_rules! vec2s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 2 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 2 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -280,9 +281,7 @@ macro_rules! vec2s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
@@ -293,10 +292,8 @@ macro_rules! vec2s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_mut_ptr(&self) -> *mut $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
             }
         }
 
@@ -832,7 +829,7 @@ macro_rules! vec3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 3)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 3)
                 }
             }
 
@@ -841,7 +838,7 @@ macro_rules! vec3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 3 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 3 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -850,7 +847,7 @@ macro_rules! vec3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 3)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 3)
                 }
             }
 
@@ -859,7 +856,7 @@ macro_rules! vec3s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 3 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 3 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -872,9 +869,7 @@ macro_rules! vec3s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
@@ -885,10 +880,8 @@ macro_rules! vec3s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_mut_ptr(&self) -> *mut $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
             }
         }
 
@@ -1419,7 +1412,7 @@ macro_rules! vec4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts(self as *const $n as *const $t, 4)
                 }
             }
 
@@ -1428,7 +1421,7 @@ macro_rules! vec4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts(std::mem::transmute(self), 4 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts(self as *const $n as *const u8, 4 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -1437,7 +1430,7 @@ macro_rules! vec4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 4)
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut $t, 4)
                 }
             }
 
@@ -1446,7 +1439,7 @@ macro_rules! vec4s {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
                 unsafe {
-                    std::slice::from_raw_parts_mut(std::mem::transmute(self), 4 * std::mem::size_of::<$t>())
+                    std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 4 * std::mem::size_of::<$t>())
                 }
             }
 
@@ -1459,9 +1452,7 @@ macro_rules! vec4s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+                 self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
@@ -1472,10 +1463,8 @@ macro_rules! vec4s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_mut_ptr(&self) -> *mut $t {
-                unsafe {
-                    std::mem::transmute(self)
-                }
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
             }
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -453,7 +453,30 @@ macro_rules! vec2s {
             fn neg(self) -> $n {
                 self * $t::from(-1.0)
             }
-        })+
+        }
+
+        impl Index<usize> for $n {
+            type Output = $t;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                match index {
+                    0 => &self.x,
+                    1 => &self.y,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                match index {
+                    0 => &mut self.x,
+                    1 => &mut self.y,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+        )+
     };
 }
 
@@ -1034,7 +1057,32 @@ macro_rules! vec3s {
             fn neg(self) -> $n {
                 self * $t::from(-1.0)
             }
-        })+
+        }
+
+        impl Index<usize> for $n {
+            type Output = $t;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                match index {
+                    0 => &self.x,
+                    1 => &self.y,
+                    2 => &self.z,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                match index {
+                    0 => &mut self.x,
+                    1 => &mut self.y,
+                    2 => &mut self.z,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+        )+
     }
 }
 
@@ -1602,7 +1650,34 @@ macro_rules! vec4s {
             fn neg(self) -> $n {
                 self * $t::from(-1.0)
             }
-        })+
+        }
+
+        impl Index<usize> for $n {
+            type Output = $t;
+
+            fn index(&self, index: usize) -> &Self::Output {
+                match index {
+                    0 => &self.x,
+                    1 => &self.y,
+                    2 => &self.z,
+                    3 => &self.w,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+
+        impl IndexMut<usize> for $n {
+            fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+                match index {
+                    0 => &mut self.x,
+                    1 => &mut self.y,
+                    2 => &mut self.z,
+                    3 => &mut self.w,
+                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
+                }
+            }
+        }
+        )+
     }
 }
 


### PR DESCRIPTION
- Adds slice/ptr accessors to BiVec
- Fixes all clippy warnings. It didn't like the transmutes, so they are changed to safe pointer casts now (removes unsafe as well).
- Fixed as_mut_ptr not borrowing the type mutably.
