### PR TITLE
Aabb need Copy trait + linear iterators of volumes

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -1,3 +1,4 @@
+use std::convert::{TryFrom, TryInto};
 use std::ops::*;
 
 pub trait MulAdd<A = Self, B = Self> {
@@ -15,7 +16,6 @@ impl MulAdd<u32, u32> for u32 {
         (self * a) + b
     }
 }
-
 
 impl MulAdd<i32, i32> for i32 {
     type Output = i32;
@@ -213,6 +213,11 @@ macro_rules! vec2i {
                 }
             }
 
+            #[inline]
+            pub fn as_array(&self) -> [$t; 2] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
 
             #[inline]
             pub fn as_byte_slice(&self) -> &[u8] {
@@ -664,6 +669,12 @@ macro_rules! vec3i {
             }
 
             #[inline]
+            pub fn as_array(&self) -> [$t; 3] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_byte_slice(&self) -> &[u8] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -1088,6 +1099,12 @@ macro_rules! vec4i {
             }
 
             #[inline]
+            pub fn as_array(&self) -> [$t; 4] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_byte_slice(&self) -> &[u8] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -1338,13 +1355,9 @@ vec4i!(Vec4i, Vec2i, Vec3i => i32);
 impl From<Vec3u> for Vec2u {
     #[inline]
     fn from(vec: Vec3u) -> Self {
-        Self {
-            x: vec.x,
-            y: vec.y,
-        }
+        Self { x: vec.x, y: vec.y }
     }
 }
-
 
 impl From<Vec3u> for Vec4u {
     #[inline]
@@ -1372,13 +1385,9 @@ impl From<Vec4u> for Vec3u {
 impl From<Vec3i> for Vec2i {
     #[inline]
     fn from(vec: Vec3i) -> Self {
-        Self {
-            x: vec.x,
-            y: vec.y,
-        }
+        Self { x: vec.x, y: vec.y }
     }
 }
-
 
 impl From<Vec3i> for Vec4i {
     #[inline]
@@ -1400,5 +1409,29 @@ impl From<Vec4i> for Vec3i {
             y: vec.y,
             z: vec.z,
         }
+    }
+}
+
+impl TryFrom<Vec3u> for Vec3i {
+    type Error = <i32 as TryFrom<u32>>::Error;
+
+    fn try_from(rhv: Vec3u) -> Result<Self, Self::Error> {
+        Ok(Self {
+            x: rhv.x.try_into()?,
+            y: rhv.y.try_into()?,
+            z: rhv.z.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<Vec3i> for Vec3u {
+    type Error = <u32 as TryFrom<i32>>::Error;
+
+    fn try_from(rhv: Vec3i) -> Result<Self, Self::Error> {
+        Ok(Self {
+            x: rhv.x.try_into()?,
+            y: rhv.y.try_into()?,
+            z: rhv.z.try_into()?,
+        })
     }
 }

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -50,7 +50,7 @@ macro_rules! mat2s {
             }
 
             #[inline]
-            pub fn as_array(&self) -> &[$t; 4] {
+            pub fn as_array(&self) -> [$t; 4] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }
@@ -420,7 +420,7 @@ macro_rules! mat3s {
             }
 
             #[inline]
-            pub fn as_array(&self) -> &[$t; 9] {
+            pub fn as_array(&self) -> [$t; 9] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }
@@ -897,7 +897,7 @@ macro_rules! mat4s {
             }
 
             #[inline]
-            pub fn as_array(&self) -> &[$t; 16] {
+            pub fn as_array(&self) -> [$t; 16] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -50,6 +50,18 @@ macro_rules! mat2s {
             }
 
             #[inline]
+            pub fn as_array(&self) -> &[$t; 4] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
+            pub fn as_component_array(&self) -> &[$vt; 2] {
+                use std::convert::TryInto;
+                self.as_component_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -405,6 +417,18 @@ macro_rules! mat3s {
             #[inline]
             pub fn layout() -> alloc::alloc::Layout {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
+            }
+
+            #[inline]
+            pub fn as_array(&self) -> &[$t; 9] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
+            pub fn as_component_array(&self) -> &[$vt; 3] {
+                use std::convert::TryInto;
+                self.as_component_slice().try_into().unwrap()
             }
 
             #[inline]
@@ -873,6 +897,18 @@ macro_rules! mat4s {
             }
 
             #[inline]
+            pub fn as_array(&self) -> &[$t; 16] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
+            pub fn as_component_array(&self) -> &[$vt; 4] {
+                use std::convert::TryInto;
+                self.as_component_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -1061,7 +1097,8 @@ mat4s!(Mat4 => Rotor3, Bivec3, Vec4, Vec3, f32, Wat4 => WRotor3, WBivec3, Wec4, 
 // Utility functions for mat4 specific code
 impl Mat4 {
     pub fn translate(&mut self, translation: &Vec3) {
-        self[0][3] += self[0][0] * translation[0] + self[0][1] * translation[1] + self[0][2] * translation[2];
+        self[0][3] +=
+            self[0][0] * translation[0] + self[0][1] * translation[1] + self[0][2] * translation[2];
     }
 
     pub fn translated(&self, translation: &Vec3) -> Mat4 {
@@ -1075,9 +1112,11 @@ impl Mat4 {
 // Utility functions for mat4 specific code
 impl Wat4 {
     pub fn translate(&mut self, translation: &Wec3) {
-        let res = self[0][3] + self[0][0] * translation[0] + self[0][1] * translation[1] + self[0][2] * translation[2];
+        let res = self[0][3]
+            + self[0][0] * translation[0]
+            + self[0][1] * translation[1]
+            + self[0][2] * translation[2];
         self[0][3] = res;
-
     }
 
     pub fn translated(&self, translation: &Wec3) -> Wat4 {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -236,7 +236,7 @@ macro_rules! vec2s {
             }
 
             #[inline]
-            pub fn as_array(&self) -> &[$t; 2] {
+            pub fn as_array(&self) -> [$t; 2] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }
@@ -843,7 +843,7 @@ macro_rules! vec3s {
             }
 
             #[inline]
-            pub fn as_array(&self) -> &[$t; 3] {
+            pub fn as_array(&self) -> [$t; 3] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }
@@ -1438,7 +1438,7 @@ macro_rules! vec4s {
             }
 
 #           [inline]
-            pub fn as_array(&self) -> &[$t; 4] {
+            pub fn as_array(&self) -> [$t; 4] {
                 use std::convert::TryInto;
                 self.as_slice().try_into().unwrap()
             }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -236,6 +236,12 @@ macro_rules! vec2s {
             }
 
             #[inline]
+            pub fn as_array(&self) -> &[$t; 2] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -837,6 +843,12 @@ macro_rules! vec3s {
             }
 
             #[inline]
+            pub fn as_array(&self) -> &[$t; 3] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
+            }
+
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -1423,6 +1435,12 @@ macro_rules! vec4s {
             #[inline]
             pub fn layout() -> alloc::alloc::Layout {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
+            }
+
+#           [inline]
+            pub fn as_array(&self) -> &[$t; 4] {
+                use std::convert::TryInto;
+                self.as_slice().try_into().unwrap()
             }
 
             #[inline]


### PR DESCRIPTION
- Aabb volumes weren't `Copy`, even though they are just 2 Vec3s. Fixed.
- Added basic linear iterators to Aabb volumes. They iterator row-wise, and have configurable stride. `iter()` defaults to a stride of 1.