### PR TITLE
Add ’refract` and change `refracted` methods on `vec` types

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -517,7 +517,12 @@ impl From<Wec3> for Wec2 {
 
 impl Vec2 {
     #[inline]
-    pub fn refracted(&mut self, normal: Self, eta: f32) -> Self {
+    pub fn refract(&mut self, normal: Self, eta: f32) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f32) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);
@@ -558,7 +563,12 @@ impl Wec2 {
     }
 
     #[inline]
-    pub fn refracted(&mut self, normal: Self, eta: f32x4) -> Self {
+    pub fn refract(&mut self, normal: Self, eta: f32x4) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f32x4) -> Self {
         let n = normal;
         let i = *self;
         let one = f32x4::from(1.0);
@@ -1145,7 +1155,12 @@ impl From<Wec4> for Wec3 {
 
 impl Vec3 {
     #[inline]
-    pub fn refracted(&mut self, normal: Self, eta: f32) -> Self {
+    pub fn refract(&mut self, normal: Self, eta: f32) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f32) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);
@@ -1188,7 +1203,12 @@ impl Wec3 {
     }
 
     #[inline]
-    pub fn refracted(&mut self, normal: Self, eta: f32x4) -> Self {
+    pub fn refract(&mut self, normal: Self, eta: f32x4) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f32x4) -> Self {
         let n = normal;
         let i = *self;
         let one = f32x4::from(1.0);
@@ -1722,7 +1742,12 @@ impl From<Wec3> for Wec4 {
 
 impl Vec4 {
     #[inline]
-    pub fn refracted(&mut self, normal: Self, eta: f32) -> Self {
+    pub fn refract(&mut self, normal: Self, eta: f32) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f32) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);


### PR DESCRIPTION
- adds `refract : &mut self -> ()` method to types in the `vec` module
- changes `refracted` from `&mut self -> Self` to `&self -> Self`