### PR TITLE
Implement PartialEq for Mat[2,3,4] and Vec[2,3,4]

### DIFF
--- a/src/mat.rs
+++ b/src/mat.rs
@@ -186,6 +186,16 @@ macro_rules! mat2s {
 
 mat2s!(Mat2 => Mat3, Vec3, Vec2, f32, Wat2 => Wat3, Wec3, Wec2, f32x4);
 
+impl PartialEq for Mat2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.cols[0] == other.cols[0] && self.cols[1] == other.cols[1]
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.cols[0] != other.cols[0] || self.cols[1] != other.cols[1]
+    }
+}
+
 macro_rules! mat3s {
     ($($n:ident => $rt:ident, $bt:ident, $m4t:ident, $v4t:ident, $v2t:ident, $vt:ident, $t:ident),+) => {
         /// A 3x3 square matrix.
@@ -591,6 +601,20 @@ macro_rules! mat3s {
 }
 
 mat3s!(Mat3 => Rotor3, Bivec3, Mat4, Vec4, Vec2, Vec3, f32, Wat3 => WRotor3, WBivec3, Wat4, Wec4, Wec2, Wec3, f32x4);
+
+impl PartialEq for Mat3 {
+    fn eq(&self, other: &Self) -> bool {
+        self.cols[0] == other.cols[0]
+            && self.cols[1] == other.cols[1]
+            && self.cols[2] == other.cols[2]
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.cols[0] != other.cols[0]
+            || self.cols[1] != other.cols[1]
+            || self.cols[2] != other.cols[2]
+    }
+}
 
 macro_rules! mat4s {
     ($($n:ident => $rt:ident, $bt:ident, $vt:ident, $v3t:ident, $t:ident),+) => {
@@ -1093,6 +1117,22 @@ macro_rules! mat4s {
 }
 
 mat4s!(Mat4 => Rotor3, Bivec3, Vec4, Vec3, f32, Wat4 => WRotor3, WBivec3, Wec4, Wec3, f32x4);
+
+impl PartialEq for Mat4 {
+    fn eq(&self, other: &Self) -> bool {
+        self.cols[0] == other.cols[0]
+            && self.cols[1] == other.cols[1]
+            && self.cols[2] == other.cols[2]
+            && self.cols[3] == other.cols[3]
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.cols[0] != other.cols[0]
+            || self.cols[1] != other.cols[1]
+            || self.cols[2] != other.cols[2]
+            || self.cols[3] != other.cols[3]
+    }
+}
 
 // Utility functions for mat4 specific code
 impl Mat4 {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -589,6 +589,16 @@ impl Wec2 {
     }
 }
 
+impl PartialEq for Vec2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y
+    }
+}
+
 macro_rules! vec3s {
     ($(($v2t:ident, $n:ident, $bn:ident, $rn:ident, $v4t:ident) => $t:ident),+) => {
         /// A set of three coordinates which may be interpreted as a point or vector in 3d space,
@@ -1261,6 +1271,16 @@ impl From<[Vec3; 4]> for Wec3 {
     }
 }
 
+impl PartialEq for Vec3 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y && self.z == other.z
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y || self.z != other.z
+    }
+}
+
 macro_rules! vec4s {
     ($($n:ident, $v2t:ident, $v3t:ident => $t:ident),+) => {
         /// A set of four coordinates which may be interpreted as a point or vector in 4d space,
@@ -1835,5 +1855,15 @@ impl From<[Vec4; 4]> for Wec4 {
             z: f32x4::from([vecs[0].z, vecs[1].z, vecs[2].z, vecs[3].z]),
             w: f32x4::from([vecs[0].w, vecs[1].w, vecs[2].w, vecs[3].w]),
         }
+    }
+}
+
+impl PartialEq for Vec4 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y && self.z == other.z && self.w == other.w
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y || self.z != other.z || self.w != other.w
     }
 }


### PR DESCRIPTION
Implements PartialEq for Mat[2,3,4] and Vec[2,3,4]. I didn't do the wide types since I don't use them and it seems complicated