### PR TITLE
Updated Aabb. Added surface_area, largest_axis, and join which return…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.5"
 authors = ["Gray Olson <gray@grayolson.com>"]
 edition = "2018"
 description = "A crate to do linear algebra, fast."
+documentation = "https://docs.rs/ultraviolet/"
 repository = "https://github.com/termhn/ultraviolet"
 readme = "README.md"
 keywords = ["simd", "wide", "graphics", "math", "linear-algebra"]

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -265,6 +265,33 @@ macro_rules! impl_aabb {
                 self.size().x * self.size().y * self.size().z
             }
 
+            /// Returns the smallest bounding box that contains both this Aabb and other.
+            #[inline]
+            #[must_use]
+            pub fn join(&self, other: &Self) -> Self {
+                Self::new(
+                    $v3t::new(self.min.x.min(other.min.x),
+                        self.min.y.min(other.min.y),
+                        self.min.z.min(other.min.z)),
+                    $v3t::new(self.max.x.max(other.max.x),
+                        self.max.y.max(other.max.y),
+                        self.max.z.max(other.max.z)
+                    )
+                )
+            }
+
+            #[inline]
+            #[must_use]
+            pub fn largest_axis(&self) -> usize {
+                if self.size().x > self.size().y && self.size().x > self.size().z {
+                    0
+                } else if self.size().y > self.size().z {
+                    1
+                } else {
+                    2
+                }
+            }
+
             #[inline]
             #[must_use]
             pub fn iter_stride(&self, stride: $t) -> $iter {
@@ -336,6 +363,12 @@ impl Aabb {
     pub fn iter(&self) -> AabbLinearIterator {
         self.iter_stride(1.0)
     }
+
+    #[inline]
+    #[must_use]
+    pub fn surface_area(&self) -> f32 {
+        2.0 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
+    }
 }
 
 impl Aabbu {
@@ -345,6 +378,12 @@ impl Aabbu {
     pub fn iter(&self) -> AabbuLinearIterator {
         self.iter_stride(1)
     }
+
+    #[inline]
+    #[must_use]
+    pub fn surface_area(&self) -> u32 {
+        2 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
+    }
 }
 
 impl Aabbi {
@@ -353,6 +392,12 @@ impl Aabbi {
     #[must_use]
     pub fn iter(&self) -> AabbiLinearIterator {
         self.iter_stride(1)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn surface_area(&self) -> i32 {
+        2 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -265,7 +265,7 @@ macro_rules! impl_aabb {
                 self.size().x * self.size().y * self.size().z
             }
 
-            /// Returns the smallest bounding box that contains both this Aabb and other.
+            /// Returns the smallest bounding box that contains both this bounding box and the other bounding box.
             #[inline]
             #[must_use]
             pub fn join(&self, other: &Self) -> Self {
@@ -277,6 +277,24 @@ macro_rules! impl_aabb {
                         self.max.y.max(other.max.y),
                         self.max.z.max(other.max.z)
                     )
+                )
+            }
+
+            /// Returns the smallest bounding box that contains both this bounding box and a point.
+            #[inline]
+            #[must_use]
+            pub fn grow(&self, other: &$v3t) -> Self {
+                Self::new(
+                    $v3t::new(
+                        self.min.x.min(other.x),
+                        self.min.y.min(other.y),
+                        self.min.z.min(other.z),
+                    ),
+                    $v3t::new(
+                        self.max.x.max(other.x),
+                        self.max.y.max(other.y),
+                        self.max.z.max(other.z),
+                    ),
                 )
             }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -369,6 +369,12 @@ impl Aabb {
     pub fn surface_area(&self) -> f32 {
         2.0 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
     }
+
+    #[inline]
+    #[must_use]
+    pub fn center(&self) -> Vec3 {
+        self.min + (self.size() / 2.0)
+    }
 }
 
 impl Aabbu {
@@ -384,6 +390,12 @@ impl Aabbu {
     pub fn surface_area(&self) -> u32 {
         2 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
     }
+
+    #[inline]
+    #[must_use]
+    pub fn center(&self) -> Vec3u {
+        self.min + (self.size() / 2)
+    }
 }
 
 impl Aabbi {
@@ -398,6 +410,12 @@ impl Aabbi {
     #[must_use]
     pub fn surface_area(&self) -> i32 {
         2 * (self.size().x * self.size().y + self.size().x * self.size().z + self.size().y * self.size().z)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn center(&self) -> Vec3i {
+        self.min + (self.size() / 2)
     }
 }
 


### PR DESCRIPTION
- adds `surface_area: &self -> f32/u32/i32` method to `Aabb/Aabbu/Aabbi`
- adds `largest_axis: &self -> usize` method to `Aabb` to get the longest axis of the bounding box
- adds `center: &self -> f32/u32/i32` to get the center point of an Aabb
- adds `join: &self, other: &Self -> Self` method to `Aabb` which creates an Aabb encompassing self and other Aabbs.
- adds `grow: &self, other: &Self -> Self` method to `Aabb` which is similar to join except it takes a point for other instead of an Aabb.

I called it `join` because it's what the bvh crate uses, but I think something like `surrounding_box` might be clearer. `grow` also needs a better name.


I've also added a link to the documentation in cargo.toml so it shows up on crates.io with the link at the top alongside the Repository and Dependent Crates links. Not sure if I should make a separate PR for that or not.