### PR TITLE
F64 support

### DIFF
--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -286,6 +286,7 @@ macro_rules! bivec2s {
 }
 
 bivec2s!((Bivec2) => f32, (WBivec2) => f32x4);
+bivec2s!((Bivec2d) => f64);
 
 macro_rules! bivec3s {
     ($($bn:ident => ($vt:ident, $t:ident)),+) => {
@@ -573,3 +574,4 @@ macro_rules! bivec3s {
 }
 
 bivec3s!(Bivec3 => (Vec3, f32), WBivec3 => (Wec3, f32x4));
+bivec3s!(Bivec3d => (Vec3d, f64));

--- a/src/lerp.rs
+++ b/src/lerp.rs
@@ -22,4 +22,5 @@ macro_rules! impl_lerp {
 
 impl_lerp!(
     f32 => (Vec2, Vec3, Vec4, Bivec2, Bivec3, Rotor2, Rotor3),
+    f64 => (Vec2d, Vec3d, Vec4d, Bivec2d, Bivec3d, Rotor2d, Rotor3d),
     f32x4 => (Wec2, Wec3, Wec4, WBivec2, WBivec3, WRotor2, WRotor3));

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -208,6 +208,7 @@ macro_rules! mat2s {
 }
 
 mat2s!(Mat2 => Mat3, Vec3, Vec2, f32, Wat2 => Wat3, Wec3, Wec2, f32x4);
+mat2s!(Mat2d => Mat3d, Vec3d, Vec2d, f64);
 
 impl PartialEq for Mat2 {
     fn eq(&self, other: &Self) -> bool {
@@ -737,6 +738,7 @@ macro_rules! mat3s {
 }
 
 mat3s!(Mat3 => Rotor3, Bivec3, Mat4, Vec4, Vec2, Vec3, f32, Wat3 => WRotor3, WBivec3, Wat4, Wec4, Wec2, Wec3, f32x4);
+mat3s!(Mat3d => Rotor3d, Bivec3d, Mat4d, Vec4d, Vec2d, Vec3d, f64);
 
 impl PartialEq for Mat3 {
     fn eq(&self, other: &Self) -> bool {
@@ -1433,6 +1435,7 @@ macro_rules! mat4s {
 }
 
 mat4s!(Mat4 => Rotor3, Bivec3, Vec4, Vec3, f32, Wat4 => WRotor3, WBivec3, Wec4, Wec3, f32x4);
+mat4s!(Mat4d => Rotor3d, Bivec3d, Vec4d, Vec3d, f64);
 
 impl PartialEq for Mat4 {
     fn eq(&self, other: &Self) -> bool {

--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -317,6 +317,7 @@ macro_rules! rotor2s {
 }
 
 rotor2s!(Rotor2 => (Mat2, Vec2, Bivec2, f32), WRotor2 => (Wat2, Wec2, WBivec2, f32x4));
+rotor2s!(Rotor2d => (Mat2d, Vec2d, Bivec2d, f64));
 
 macro_rules! rotor3s {
     ($($rn:ident => ($mt:ident, $vt:ident, $bt:ident, $t:ident)),+) => {
@@ -675,6 +676,7 @@ macro_rules! rotor3s {
 }
 
 rotor3s!(Rotor3 => (Mat3, Vec3, Bivec3, f32), WRotor3 => (Wat3, Wec3, WBivec3, f32x4));
+rotor3s!(Rotor3d => (Mat3d, Vec3d, Bivec3d, f64));
 
 #[cfg(test)]
 mod test {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -161,7 +161,8 @@ macro_rules! isometries {
 
 isometries!(
     Isometry2 => (Mat3, Rotor2, Vec2, f32), WIsometry2 => (Wat3, WRotor2, Wec2, f32x4),
-    Isometry3 => (Mat4, Rotor3, Vec3, f32), WIsometry3 => (Wat4, WRotor3, Wec3, f32x4)
+    Isometry3 => (Mat4, Rotor3, Vec3, f32), WIsometry3 => (Wat4, WRotor3, Wec3, f32x4),
+    Isometry2d => (Mat3d, Rotor2d, Vec2d, f64), Isometry3d => (Mat4d, Rotor3d, Vec3d, f64)
 );
 
 macro_rules! similarities {
@@ -345,5 +346,6 @@ macro_rules! similarities {
 
 similarities!(
     Similarity2 => (Mat3, Rotor2, Vec2, f32), WSimilarity2 => (Wat3, WRotor2, Wec2, f32x4),
-    Similarity3 => (Mat4, Rotor3, Vec3, f32), WSimilarity3 => (Wat4, WRotor3, Wec3, f32x4)
+    Similarity3 => (Mat4, Rotor3, Vec3, f32), WSimilarity3 => (Wat4, WRotor3, Wec3, f32x4),
+    Similarity2d => (Mat3d, Rotor2d, Vec2d, f64), Similarity3d => (Mat4d, Rotor3d, Vec3d, f64)
 );

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,6 +22,12 @@ impl EqualsEps for f32 {
     }
 }
 
+impl EqualsEps for f64 {
+    fn eq_eps(self, other: Self) -> bool {
+        (self - other).abs() <= 0.01
+    }
+}
+
 #[macro_export]
 macro_rules! derive_default_identity {
     ($t:ident) => {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -503,6 +503,7 @@ macro_rules! vec2s {
 }
 
 vec2s!((Vec2, Bivec2, Rotor2, Vec3, Vec4) => f32, (Wec2, WBivec2, WRotor2, Wec3, Wec4) => f32x4);
+vec2s!((Vec2d, Bivec2d, Rotor2d, Vec3d, Vec4d) => f64);
 
 impl From<[Vec2; 4]> for Wec2 {
     #[inline]
@@ -517,6 +518,13 @@ impl From<[Vec2; 4]> for Wec2 {
 impl From<Vec3> for Vec2 {
     #[inline]
     fn from(vec: Vec3) -> Self {
+        Self { x: vec.x, y: vec.y }
+    }
+}
+
+impl From<Vec3d> for Vec2d {
+    #[inline]
+    fn from(vec: Vec3d) -> Self {
         Self { x: vec.x, y: vec.y }
     }
 }
@@ -536,6 +544,26 @@ impl Vec2 {
 
     #[inline]
     pub fn refracted(&self, normal: Self, eta: f32) -> Self {
+        let n = normal;
+        let i = *self;
+        let ndi = n.dot(i);
+        let k = 1.0 - eta * eta * (1.0 - ndi * ndi);
+        if k < 0.0 {
+            Self::zero()
+        } else {
+            i * eta - (eta * ndi + k.sqrt()) * n
+        }
+    }
+}
+
+impl Vec2d {
+    #[inline]
+    pub fn refract(&mut self, normal: Self, eta: f64) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f64) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);
@@ -597,6 +625,16 @@ impl Wec2 {
 }
 
 impl PartialEq for Vec2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y
+    }
+}
+
+impl PartialEq for Vec2d {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y
     }
@@ -1252,10 +1290,22 @@ macro_rules! vec3s {
 }
 
 vec3s!((Vec2, Vec3, Bivec3, Rotor3, Vec4) => f32, (Wec2, Wec3, WBivec3, WRotor3, Wec4) => f32x4);
+vec3s!((Vec2d, Vec3d, Bivec3d, Rotor3d, Vec4d) => f64);
 
 impl From<Vec2> for Vec3 {
     #[inline]
     fn from(vec: Vec2) -> Self {
+        Self {
+            x: vec.x,
+            y: vec.y,
+            z: 0.0,
+        }
+    }
+}
+
+impl From<Vec2d> for Vec3d {
+    #[inline]
+    fn from(vec: Vec2d) -> Self {
         Self {
             x: vec.x,
             y: vec.y,
@@ -1286,6 +1336,17 @@ impl From<Vec4> for Vec3 {
     }
 }
 
+impl From<Vec4d> for Vec3d {
+    #[inline]
+    fn from(vec: Vec4d) -> Self {
+        Self {
+            x: vec.x,
+            y: vec.y,
+            z: vec.z,
+        }
+    }
+}
+
 impl From<Wec4> for Wec3 {
     #[inline]
     fn from(vec: Wec4) -> Self {
@@ -1305,6 +1366,26 @@ impl Vec3 {
 
     #[inline]
     pub fn refracted(&self, normal: Self, eta: f32) -> Self {
+        let n = normal;
+        let i = *self;
+        let ndi = n.dot(i);
+        let k = 1.0 - eta * eta * (1.0 - ndi * ndi);
+        if k < 0.0 {
+            Self::zero()
+        } else {
+            i * eta - (eta * ndi + k.sqrt()) * n
+        }
+    }
+}
+
+impl Vec3d {
+    #[inline]
+    pub fn refract(&mut self, normal: Self, eta: f64) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f64) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);
@@ -1394,6 +1475,16 @@ impl From<[Vec3; 4]> for Wec3 {
 }
 
 impl PartialEq for Vec3 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y && self.z == other.z
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y || self.z != other.z
+    }
+}
+
+impl PartialEq for Vec3d {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y && self.z == other.z
     }
@@ -1999,10 +2090,23 @@ macro_rules! vec4s {
 }
 
 vec4s!(Vec4, Vec2, Vec3 => f32, Wec4, Wec2, Wec3 => f32x4);
+vec4s!(Vec4d, Vec2d, Vec3d => f64);
 
 impl From<Vec3> for Vec4 {
     #[inline]
     fn from(vec: Vec3) -> Self {
+        Self {
+            x: vec.x,
+            y: vec.y,
+            z: vec.z,
+            w: 0.0,
+        }
+    }
+}
+
+impl From<Vec3d> for Vec4d {
+    #[inline]
+    fn from(vec: Vec3d) -> Self {
         Self {
             x: vec.x,
             y: vec.y,
@@ -2032,6 +2136,26 @@ impl Vec4 {
 
     #[inline]
     pub fn refracted(&self, normal: Self, eta: f32) -> Self {
+        let n = normal;
+        let i = *self;
+        let ndi = n.dot(i);
+        let k = 1.0 - eta * eta * (1.0 - ndi * ndi);
+        if k < 0.0 {
+            Self::zero()
+        } else {
+            i * eta - (eta * ndi + k.sqrt()) * n
+        }
+    }
+}
+
+impl Vec4d {
+    #[inline]
+    pub fn refract(&mut self, normal: Self, eta: f64) {
+        *self = self.refracted(normal, eta);
+    }
+
+    #[inline]
+    pub fn refracted(&self, normal: Self, eta: f64) -> Self {
         let n = normal;
         let i = *self;
         let ndi = n.dot(i);
@@ -2105,6 +2229,16 @@ impl From<[Vec4; 4]> for Wec4 {
 }
 
 impl PartialEq for Vec4 {
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y && self.z == other.z && self.w == other.w
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.x != other.x || self.y != other.y || self.z != other.z || self.w != other.w
+    }
+}
+
+impl PartialEq for Vec4d {
     fn eq(&self, other: &Self) -> bool {
         self.x == other.x && self.y == other.y && self.z == other.z && self.w == other.w
     }


### PR DESCRIPTION
An initial attempt at adding f64 support to vecs, mats, rotors and bivecs. For lack of a better name I've called them `Vec2d`, `Mat3d` etc.

I haven't really written anything new; I've basically reused the existing macros to generate them. They should therefore have the same functionality as their f32 counterparts.

Not implemented yet: serde support