### PR TITLE
Const fns

### DIFF
--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -55,7 +55,7 @@ macro_rules! bivec2s {
 
         impl $bn {
             #[inline]
-            pub fn new(xy: $t) -> Self {
+            pub const fn new(xy: $t) -> Self {
                 Self {
                     xy
                 }
@@ -149,7 +149,7 @@ macro_rules! bivec2s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $bn as *const $t
             }
 
@@ -335,7 +335,7 @@ macro_rules! bivec3s {
 
         impl $bn {
             #[inline]
-            pub fn new(xy: $t, xz: $t, yz: $t) -> Self {
+            pub const fn new(xy: $t, xz: $t, yz: $t) -> Self {
                 Self {
                     xy, xz, yz
                 }
@@ -448,7 +448,7 @@ macro_rules! bivec3s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $bn as *const $t
             }
 

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -18,7 +18,7 @@ macro_rules! mat2s {
 
         impl $n {
             #[inline]
-            pub fn new(col1: $vt, col2: $vt) -> Self {
+            pub const fn new(col1: $vt, col2: $vt) -> Self {
                 $n {
                     cols: [col1, col2],
                 }
@@ -252,7 +252,7 @@ macro_rules! mat3s {
 
         impl $n {
             #[inline]
-            pub fn new(col1: $vt, col2: $vt, col3: $vt) -> Self {
+            pub const fn new(col1: $vt, col2: $vt, col3: $vt) -> Self {
                 $n {
                     cols: [col1, col2, col3],
                 }
@@ -542,7 +542,7 @@ macro_rules! mat3s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $n as *const $t
             }
 
@@ -718,7 +718,7 @@ macro_rules! mat4s {
 
         impl $n {
             #[inline]
-            pub fn new(col1: $vt, col2: $vt, col3: $vt, col4: $vt) -> Self {
+            pub const fn new(col1: $vt, col2: $vt, col3: $vt, col4: $vt) -> Self {
                 $n {
                     cols: [col1, col2, col3, col4],
                 }
@@ -1115,7 +1115,7 @@ macro_rules! mat4s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $n as *const $t
             }
 

--- a/src/mat.rs
+++ b/src/mat.rs
@@ -112,6 +112,30 @@ macro_rules! mat2s {
                     std::slice::from_raw_parts_mut(self as *mut $n as *mut u8, 4 * std::mem::size_of::<$t>())
                 }
             }
+
+            /// Returns a constant unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub const fn as_ptr(&self) -> *const $t {
+                self as *const $n as *const $t
+            }
+
+            /// Returns a mutable unsafe pointer to the underlying data in the underlying type.
+            /// This function is safe because all types here are repr(C) and can be represented
+            /// as their underlying type.
+            ///
+            /// # Safety
+            ///
+            /// It is up to the caller to correctly use this pointer and its bounds.
+            #[inline]
+            pub fn as_mut_ptr(&mut self) -> *mut $t {
+                self as *mut $n as *mut $t
+            }
         }
 
         impl Mul for $n {

--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -73,7 +73,7 @@ macro_rules! rotor2s {
 
         impl $rn {
             #[inline]
-            pub fn new(scalar: $t, bivector: $bt) -> Self {
+            pub const fn new(scalar: $t, bivector: $bt) -> Self {
                 Self {
                     s: scalar,
                     bv: bivector,
@@ -370,7 +370,7 @@ macro_rules! rotor3s {
 
         impl $rn {
             #[inline]
-            pub fn new(scalar: $t, bivector: $bt) -> Self {
+            pub const fn new(scalar: $t, bivector: $bt) -> Self {
                 Self {
                     s: scalar,
                     bv: bivector,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -28,7 +28,7 @@ macro_rules! isometries {
 
         impl $ison {
             #[inline]
-            pub fn new(translation: $vt, rotation: $rt) -> Self {
+            pub const fn new(translation: $vt, rotation: $rt) -> Self {
                 Self { translation, rotation }
             }
 
@@ -210,7 +210,7 @@ macro_rules! similarities {
 
         impl $sn {
             #[inline]
-            pub fn new(translation: $vt, rotation: $rt, scale: $t) -> Self {
+            pub const fn new(translation: $vt, rotation: $rt, scale: $t) -> Self {
                 Self { translation, rotation, scale }
             }
 

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -20,12 +20,12 @@ macro_rules! vec2s {
 
         impl $n {
             #[inline]
-            pub fn new(x: $t, y: $t) -> Self {
+            pub const fn new(x: $t, y: $t) -> Self {
                 $n { x, y }
             }
 
             #[inline]
-            pub fn broadcast(val: $t) -> Self {
+            pub const fn broadcast(val: $t) -> Self {
                 Self::new(val, val)
             }
 
@@ -114,7 +114,6 @@ macro_rules! vec2s {
             pub fn reflected(&self, normal: $n) -> Self {
                 *self - ($t::splat(2.0) * self.dot(normal) * normal)
             }
-
 
             #[inline]
             pub fn mag_sq(&self) -> $t {
@@ -247,7 +246,6 @@ macro_rules! vec2s {
                 }
             }
 
-
             #[inline]
             pub fn as_byte_slice(&self) -> &[u8] {
                 // This is safe because we are statically bounding our slices to the size of these
@@ -283,7 +281,7 @@ macro_rules! vec2s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $n as *const $t
             }
 
@@ -829,4 +827,3 @@ impl From<[DVec2; 8]> for DVec2x8 {
         }
     }
 }
-

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -21,12 +21,12 @@ macro_rules! vec3s {
 
         impl $n {
             #[inline]
-            pub fn new(x: $t, y: $t, z: $t) -> Self {
+            pub const fn new(x: $t, y: $t, z: $t) -> Self {
                 $n { x, y, z }
             }
 
             #[inline]
-            pub fn broadcast(val: $t) -> Self {
+            pub const fn broadcast(val: $t) -> Self {
                 Self::new(val, val, val)
             }
 
@@ -74,7 +74,6 @@ macro_rules! vec3s {
             pub fn from_homogeneous_vector(v: $v4t) -> Self {
                 v.into()
             }
-
 
             #[inline]
             pub fn dot(&self, other: $n) -> $t {
@@ -250,9 +249,8 @@ macro_rules! vec3s {
                 Self::broadcast($t::splat(1.0))
             }
 
-
             #[inline]
-            pub fn xy(&self) -> $v2t {
+            pub const fn xy(&self) -> $v2t {
                 $v2t::new(self.x, self.y)
             }
 
@@ -316,7 +314,7 @@ macro_rules! vec3s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                 self as *const $n as *const $t
             }
 

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -184,15 +184,14 @@ macro_rules! vec4s {
             }
 
             #[inline]
-            pub fn xy(&self) -> $v2t {
+            pub const fn xy(&self) -> $v2t {
                 $v2t::new(self.x, self.y)
             }
 
-             #[inline]
-            pub fn xyz(&self) -> $v3t {
+            #[inline]
+            pub const fn xyz(&self) -> $v3t {
                 $v3t::new(self.x, self.y, self.z)
             }
-
 
             #[inline]
             pub fn layout() -> alloc::alloc::Layout {
@@ -249,7 +248,7 @@ macro_rules! vec4s {
             ///
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
-            pub fn as_ptr(&self) -> *const $t {
+            pub const fn as_ptr(&self) -> *const $t {
                  self as *const $n as *const $t
             }
 

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -22,12 +22,12 @@ macro_rules! vec4s {
 
         impl $n {
             #[inline]
-            pub fn new<T: Into<$t>>(x: T, y: T, z: T, w: T) -> Self {
-                $n { x: x.into(), y: y.into(), z: z.into(), w: w.into() }
+            pub const fn new(x: $t, y: $t, z: $t, w: $t) -> Self {
+                $n { x, y, z, w }
             }
 
             #[inline]
-            pub fn broadcast<T: Into<$t> + Copy>(val: T) -> Self {
+            pub const fn broadcast(val: $t) -> Self {
                 Self::new(val, val, val, val)
             }
 


### PR DESCRIPTION
Makes some functions `const`, mainly `new()` and `as_ptr()`, for the various Vecs, Mats, Bivecs, Rotors and Transforms.
To make the `new()` and `broadcast()` `const` for the vec4s I've had to change their signatures - they now match the signatures for vec3s and vec2s. 
Also adds the missing `as_ptr()` and `as_mut_ptr()` for the mat2s.

Unfortunately anything involving a `splat()` is currently unable to be made `const`, which rules out the various identity and unit constructors. 