### PR TITLE
Fix `Mat3::inverse`

### DIFF
--- a/src/mat.rs
+++ b/src/mat.rs
@@ -577,7 +577,7 @@ macro_rules! mat3s {
             /// an invalid inverse. This status is not checked by the library.
             #[inline]
             pub fn inverse(&mut self) {
-                *self = self.transposed();
+                *self = self.inversed();
             }
 
             /// If this matrix is not currently invertable, this function will return


### PR DESCRIPTION
I found this typo when looking at how the inversion of 3x3 matrices was implemented...