### PR TITLE
Reference cross product on 2D wedge product docs

### DIFF
--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -75,7 +75,7 @@ macro_rules! vec2s {
             }
 
             /// The wedge (aka exterior) product of two vectors.
-
+            ///
             /// Note: Sometimes called "cross" product in 2D.
             /// Such a product is not well defined in 2 dimensions
             /// and is really just shorthand notation for a hacky operation that 

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -75,7 +75,17 @@ macro_rules! vec2s {
             }
 
             /// The wedge (aka exterior) product of two vectors.
-            ///
+
+            /// Note: Sometimes called "cross" product in 2D.
+            /// Such a product is not well defined in 2 dimensions
+            /// and is really just shorthand notation for a hacky operation that 
+            /// extends the vectors into 3 dimensions, takes the cross product,
+            /// then returns only the resulting Z component as a pseudoscalar value.
+            /// This value is will have the same value as
+            /// the resulting bivector of the wedge product in 2d (a 2d
+            /// bivector is also a kind of pseudoscalar value), so you may use
+            /// this product to calculate the same value.
+            /// 
             /// This operation results in a bivector, which represents
             /// the plane parallel to the two vectors, and which has a
             /// 'oriented area' equal to the parallelogram created by extending


### PR DESCRIPTION
Made the docs on 2D wedge product a bit more beginner friendly, since the used function name comes from exterior algebra.
Althought mathematically correct, notations often used in physics and tutorials don't go into such detail.