### PR TITLE
Implement std::iter::Sum for Vec.

### DIFF
--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -104,7 +104,7 @@ macro_rules! bivec2s {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
             }
 
-             #[inline]
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors
@@ -386,7 +386,7 @@ macro_rules! bivec3s {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
             }
 
-             #[inline]
+            #[inline]
             pub fn as_slice(&self) -> &[$t] {
                 // This is safe because we are statically bounding our slices to the size of these
                 // vectors

--- a/src/int.rs
+++ b/src/int.rs
@@ -1339,6 +1339,12 @@ macro_rules! IVec4 {
                 }
             }
         }
+
+        impl std::iter::Sum<$n> for $n {
+            fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+                iter.fold($n::zero(), Add:add)
+            }
+        }
         )+
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -739,7 +739,7 @@ macro_rules! IVec3 {
         impl From<&[$t; 3]> for $n {
             #[inline]
             fn from(comps: &[$t; 3]) -> Self {
-               Self::from(*comps)
+                Self::from(*comps)
             }
         }
 
@@ -750,7 +750,7 @@ macro_rules! IVec3 {
             }
         }
 
-       impl From<($t, $t, $t)> for $n {
+        impl From<($t, $t, $t)> for $n {
             #[inline]
             fn from(comps: ($t, $t, $t)) -> Self {
                 Self::new(comps.0, comps.1, comps.2)
@@ -1072,7 +1072,7 @@ macro_rules! IVec4 {
                 $v2t::new(self.x, self.y)
             }
 
-             #[inline]
+            #[inline]
             pub fn xyz(&self) -> $v3t {
                 $v3t::new(self.x, self.y, self.z)
             }
@@ -1134,7 +1134,7 @@ macro_rules! IVec4 {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub fn as_ptr(&self) -> *const $t {
-                 self as *const $n as *const $t
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -496,6 +496,22 @@ macro_rules! vec2s {
                 }
             }
         }
+
+        impl std::iter::Sum<$n> for $n {
+            fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+                // Kahan summation algorithm
+                // https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+                let mut sum = $n::zero();
+                let mut c = $n::zero();
+                for v in iter {
+                    let y = v - c;
+                    let t = sum + y;
+                    c = (t - sum) - y;
+                    sum = t;
+                }
+                sum
+            }
+        }
         )+
     };
 }

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -555,6 +555,22 @@ macro_rules! vec3s {
                 }
             }
         }
+
+        impl std::iter::Sum<$n> for $n {
+            fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+                // Kahan summation algorithm
+                // https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+                let mut sum = $n::zero();
+                let mut c = $n::zero();
+                for v in iter {
+                    let y = v - c;
+                    let t = sum + y;
+                    c = (t - sum) - y;
+                    sum = t;
+                }
+                sum
+            }
+        }
         )+
     }
 }

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -382,7 +382,7 @@ macro_rules! vec3s {
         impl From<&[$t; 3]> for $n {
             #[inline]
             fn from(comps: &[$t; 3]) -> Self {
-               Self::from(*comps)
+                Self::from(*comps)
             }
         }
 
@@ -393,7 +393,7 @@ macro_rules! vec3s {
             }
         }
 
-       impl From<($t, $t, $t)> for $n {
+        impl From<($t, $t, $t)> for $n {
             #[inline]
             fn from(comps: ($t, $t, $t)) -> Self {
                 Self::new(comps.0, comps.1, comps.2)

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -499,6 +499,22 @@ macro_rules! vec4s {
                 }
             }
         }
+
+        impl std::iter::Sum<$n> for $n {
+            fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+                // Kahan summation algorithm
+                // https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+                let mut sum = $n::zero();
+                let mut c = $n::zero();
+                for v in iter {
+                    let y = v - c;
+                    let t = sum + y;
+                    c = (t - sum) - y;
+                    sum = t;
+                }
+                sum
+            }
+        }
         )+
     }
 }

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -279,7 +279,7 @@ macro_rules! vec4s {
             /// It is up to the caller to correctly use this pointer and its bounds.
             #[inline]
             pub const fn as_ptr(&self) -> *const $t {
-                 self as *const $n as *const $t
+                self as *const $n as *const $t
             }
 
             /// Returns a mutable unsafe pointer to the underlying data in the underlying type.


### PR DESCRIPTION
For VecN and DVecN, use Kahan summation algorithm to reduce float-point error.

This PR also corrects some indentation.