### PR TITLE
Implement serde traits for rotors and bivector

### DIFF
--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -585,6 +585,12 @@ bivec2s!(
     (Bivec2x8) => f32x8
 );
 
+impl std::cmp::PartialEq for Bivec2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.xy == other.xy
+    }
+}
+
 #[cfg(feature = "f64")]
 bivec2s!(
     (DBivec2) => f64,
@@ -597,6 +603,12 @@ bivec3s!(
     Bivec3x4 => (Vec3x4, f32x4),
     Bivec3x8 => (Vec3x8, f32x8)
 );
+
+impl std::cmp::PartialEq for Bivec3 {
+    fn eq(&self, other: &Self) -> bool {
+        self.xy == other.xy && self.xz == other.xz && self.yz == other.yz
+    }
+}
 
 #[cfg(feature = "f64")]
 bivec3s!(

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1101,13 +1101,12 @@ impl<'de> Deserialize<'de> for Bivec3 {
 #[cfg(test)]
 mod bivec_serde_tests {
     use crate::bivec::{Bivec2, Bivec3};
-    use serde_test::{assert_ser_tokens, Token, Deserializer};
     use serde::Deserialize;
+    use serde_test::{assert_ser_tokens, Deserializer, Token};
 
     // This is a workarround for testing despite the fact that `Bivec2` does not implement
     // PartialEq. The code is copied and paste from the serde_test library.
-    pub fn assert_de_tokens_bivec2<'de>(value: &Bivec2, tokens: &'de [Token])
-    {
+    pub fn assert_de_tokens_bivec2<'de>(value: &Bivec2, tokens: &'de [Token]) {
         let mut de = Deserializer::new(tokens);
         let mut deserialized_val = match Bivec2::deserialize(&mut de) {
             Ok(v) => {
@@ -1166,8 +1165,7 @@ mod bivec_serde_tests {
         );
     }
 
-    pub fn assert_de_tokens_bivec3<'de>(value: &Bivec3, tokens: &'de [Token])
-    {
+    pub fn assert_de_tokens_bivec3<'de>(value: &Bivec3, tokens: &'de [Token]) {
         let mut de = Deserializer::new(tokens);
         let mut deserialized_val = match Bivec3::deserialize(&mut de) {
             Ok(v) => {
@@ -1459,13 +1457,12 @@ impl<'de> Deserialize<'de> for Rotor3 {
 mod rotor_serde_tests {
     use crate::bivec::{Bivec2, Bivec3};
     use crate::rotor::{Rotor2, Rotor3};
-    use serde_test::{assert_ser_tokens, Token, Deserializer};
     use serde::Deserialize;
+    use serde_test::{assert_ser_tokens, Deserializer, Token};
 
     // This is a workarround for testing despite the fact that `Rotor2` does not implement
     // PartialEq. The code is copied and paste from the serde_test library.
-    pub fn assert_de_tokens_rotor2<'de>(value: &Rotor2, tokens: &'de [Token])
-    {
+    pub fn assert_de_tokens_rotor2<'de>(value: &Rotor2, tokens: &'de [Token]) {
         let mut de = Deserializer::new(tokens);
         let mut deserialized_val = match Rotor2::deserialize(&mut de) {
             Ok(v) => {
@@ -1542,8 +1539,7 @@ mod rotor_serde_tests {
         );
     }
 
-    pub fn assert_de_tokens_rotor3<'de>(value: &Rotor3, tokens: &'de [Token])
-    {
+    pub fn assert_de_tokens_rotor3<'de>(value: &Rotor3, tokens: &'de [Token]) {
         let mut de = Deserializer::new(tokens);
         let mut deserialized_val = match Rotor3::deserialize(&mut de) {
             Ok(v) => {

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1102,43 +1102,13 @@ impl<'de> Deserialize<'de> for Bivec3 {
 mod bivec_serde_tests {
     use crate::bivec::{Bivec2, Bivec3};
     use serde::Deserialize;
-    use serde_test::{assert_ser_tokens, Deserializer, Token};
-
-    // This is a workarround for testing despite the fact that `Bivec2` does not implement
-    // PartialEq. The code is copied and paste from the serde_test library.
-    pub fn assert_de_tokens_bivec2<'de>(value: &Bivec2, tokens: &'de [Token]) {
-        let mut de = Deserializer::new(tokens);
-        let mut deserialized_val = match Bivec2::deserialize(&mut de) {
-            Ok(v) => {
-                assert_eq!(v.xy, value.xy);
-                v
-            }
-            Err(e) => panic!("tokens failed to deserialize: {}", e),
-        };
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-
-        // Do the same thing for deserialize_in_place. This isn't *great* because a
-        // no-op impl of deserialize_in_place can technically succeed here. Still,
-        // this should catch a lot of junk.
-        let mut de = Deserializer::new(tokens);
-        match Bivec2::deserialize_in_place(&mut de, &mut deserialized_val) {
-            Ok(()) => {
-                assert_eq!(deserialized_val.xy, value.xy);
-            }
-            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
-        }
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-    }
+    use serde_test::{assert_tokens, Deserializer, Token};
 
     #[test]
     fn bivec2() {
         let bivec2 = Bivec2::new(0.78);
 
-        assert_ser_tokens(
+        assert_tokens(
             &bivec2,
             &[
                 Token::Struct {
@@ -1150,75 +1120,13 @@ mod bivec_serde_tests {
                 Token::StructEnd,
             ],
         );
-
-        assert_de_tokens_bivec2(
-            &bivec2,
-            &[
-                Token::Struct {
-                    name: "Bivec2",
-                    len: 1,
-                },
-                Token::Str("xy"),
-                Token::F32(0.78),
-                Token::StructEnd,
-            ],
-        );
-    }
-
-    pub fn assert_de_tokens_bivec3<'de>(value: &Bivec3, tokens: &'de [Token]) {
-        let mut de = Deserializer::new(tokens);
-        let mut deserialized_val = match Bivec3::deserialize(&mut de) {
-            Ok(v) => {
-                assert_eq!(v.xy, value.xy);
-                assert_eq!(v.xz, value.xz);
-                assert_eq!(v.yz, value.yz);
-                v
-            }
-            Err(e) => panic!("tokens failed to deserialize: {}", e),
-        };
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-
-        // Do the same thing for deserialize_in_place. This isn't *great* because a
-        // no-op impl of deserialize_in_place can technically succeed here. Still,
-        // this should catch a lot of junk.
-        let mut de = Deserializer::new(tokens);
-        match Bivec3::deserialize_in_place(&mut de, &mut deserialized_val) {
-            Ok(()) => {
-                assert_eq!(deserialized_val.xy, value.xy);
-                assert_eq!(deserialized_val.xz, value.xz);
-                assert_eq!(deserialized_val.yz, value.yz);
-            }
-            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
-        }
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
     }
 
     #[test]
     fn bivec3() {
         let bivec3 = Bivec3::new(0.78, 0.36, 0.63);
 
-        assert_ser_tokens(
-            &bivec3,
-            &[
-                Token::Struct {
-                    name: "Bivec3",
-                    len: 3,
-                },
-                Token::Str("xy"),
-                Token::F32(0.78),
-                Token::Str("xz"),
-                Token::F32(0.36),
-                Token::Str("yz"),
-                Token::F32(0.63),
-                Token::StructEnd,
-            ],
-        );
-
-        assert_de_tokens_bivec3(
+        assert_tokens(
             &bivec3,
             &[
                 Token::Struct {
@@ -1458,45 +1366,13 @@ mod rotor_serde_tests {
     use crate::bivec::{Bivec2, Bivec3};
     use crate::rotor::{Rotor2, Rotor3};
     use serde::Deserialize;
-    use serde_test::{assert_ser_tokens, Deserializer, Token};
-
-    // This is a workarround for testing despite the fact that `Rotor2` does not implement
-    // PartialEq. The code is copied and paste from the serde_test library.
-    pub fn assert_de_tokens_rotor2<'de>(value: &Rotor2, tokens: &'de [Token]) {
-        let mut de = Deserializer::new(tokens);
-        let mut deserialized_val = match Rotor2::deserialize(&mut de) {
-            Ok(v) => {
-                assert_eq!(v.s, value.s);
-                assert_eq!(v.bv.xy, value.bv.xy);
-                v
-            }
-            Err(e) => panic!("tokens failed to deserialize: {}", e),
-        };
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-
-        // Do the same thing for deserialize_in_place. This isn't *great* because a
-        // no-op impl of deserialize_in_place can technically succeed here. Still,
-        // this should catch a lot of junk.
-        let mut de = Deserializer::new(tokens);
-        match Rotor2::deserialize_in_place(&mut de, &mut deserialized_val) {
-            Ok(()) => {
-                assert_eq!(deserialized_val.s, value.s);
-                assert_eq!(deserialized_val.bv.xy, value.bv.xy);
-            }
-            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
-        }
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-    }
+    use serde_test::{assert_tokens, Deserializer, Token};
 
     #[test]
     fn bivec2() {
         let rotor2 = Rotor2::new(1., Bivec2::new(0.78));
 
-        assert_ser_tokens(
+        assert_tokens(
             &rotor2,
             &[
                 Token::Struct {
@@ -1516,93 +1392,13 @@ mod rotor_serde_tests {
                 Token::StructEnd,
             ],
         );
-
-        assert_de_tokens_rotor2(
-            &rotor2,
-            &[
-                Token::Struct {
-                    name: "Rotor2",
-                    len: 2,
-                },
-                Token::Str("s"),
-                Token::F32(1.),
-                Token::Str("bv"),
-                Token::Struct {
-                    name: "Bivec2",
-                    len: 1,
-                },
-                Token::Str("xy"),
-                Token::F32(0.78),
-                Token::StructEnd,
-                Token::StructEnd,
-            ],
-        );
-    }
-
-    pub fn assert_de_tokens_rotor3<'de>(value: &Rotor3, tokens: &'de [Token]) {
-        let mut de = Deserializer::new(tokens);
-        let mut deserialized_val = match Rotor3::deserialize(&mut de) {
-            Ok(v) => {
-                assert_eq!(v.s, value.s);
-                assert_eq!(v.bv.xy, value.bv.xy);
-                assert_eq!(v.bv.xz, value.bv.xz);
-                assert_eq!(v.bv.yz, value.bv.yz);
-                v
-            }
-            Err(e) => panic!("tokens failed to deserialize: {}", e),
-        };
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
-
-        // Do the same thing for deserialize_in_place. This isn't *great* because a
-        // no-op impl of deserialize_in_place can technically succeed here. Still,
-        // this should catch a lot of junk.
-        let mut de = Deserializer::new(tokens);
-        match Rotor3::deserialize_in_place(&mut de, &mut deserialized_val) {
-            Ok(()) => {
-                assert_eq!(deserialized_val.s, value.s);
-                assert_eq!(deserialized_val.bv.xy, value.bv.xy);
-                assert_eq!(deserialized_val.bv.xz, value.bv.xz);
-                assert_eq!(deserialized_val.bv.yz, value.bv.yz);
-            }
-            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
-        }
-        if de.remaining() > 0 {
-            panic!("{} remaining tokens", de.remaining());
-        }
     }
 
     #[test]
     fn rotor3() {
         let rotor3 = Rotor3::new(1., Bivec3::new(0.78, 0.36, 0.63));
 
-        assert_ser_tokens(
-            &rotor3,
-            &[
-                Token::Struct {
-                    name: "Rotor3",
-                    len: 2,
-                },
-                Token::Str("s"),
-                Token::F32(1.),
-                Token::Str("bv"),
-                Token::Struct {
-                    name: "Bivec3",
-                    len: 3,
-                },
-                Token::Str("xy"),
-                Token::F32(0.78),
-                Token::Str("xz"),
-                Token::F32(0.36),
-                Token::Str("yz"),
-                Token::F32(0.63),
-                Token::StructEnd,
-                Token::StructEnd,
-            ],
-        );
-
-        assert_de_tokens_rotor3(
+        assert_tokens(
             &rotor3,
             &[
                 Token::Struct {

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1104,6 +1104,8 @@ mod bivec_serde_tests {
     use serde_test::{assert_ser_tokens, Token, Deserializer};
     use serde::Deserialize;
 
+    // This is a workarround for testing despite the fact that `Bivec2` does not implement
+    // PartialEq. The code is copied and paste from the serde_test library.
     pub fn assert_de_tokens_bivec2<'de>(value: &Bivec2, tokens: &'de [Token])
     {
         let mut de = Deserializer::new(tokens);
@@ -1231,6 +1233,400 @@ mod bivec_serde_tests {
                 Token::F32(0.36),
                 Token::Str("yz"),
                 Token::F32(0.63),
+                Token::StructEnd,
+            ],
+        );
+    }
+}
+
+impl Serialize for Rotor2 {
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Rotor2", 2)?;
+        state.serialize_field("s", &self.s)?;
+        state.serialize_field("bv", &self.bv)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Rotor2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            S,
+            Bv,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("`s` or `bv`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "s" => Ok(Field::S),
+                            "bv" => Ok(Field::Bv),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Rotor2Visitor;
+
+        impl<'de> Visitor<'de> for Rotor2Visitor {
+            type Value = Rotor2;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct Rotor2")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Rotor2, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let s = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let bv = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                Ok(Rotor2::new(s, bv))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Rotor2, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut s = None;
+                let mut bv = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::S => {
+                            if s.is_some() {
+                                return Err(serde::de::Error::duplicate_field("s"));
+                            }
+                            s = Some(map.next_value()?);
+                        }
+                        Field::Bv => {
+                            if bv.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bv"));
+                            }
+                            bv = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let s = s.ok_or_else(|| serde::de::Error::missing_field("s"))?;
+                let bv = bv.ok_or_else(|| serde::de::Error::missing_field("bv"))?;
+                Ok(Rotor2::new(s, bv))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["s", "bv"];
+
+        deserializer.deserialize_struct("Rotor2", FIELDS, Rotor2Visitor)
+    }
+}
+
+impl Serialize for Rotor3 {
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Rotor3", 2)?;
+        state.serialize_field("s", &self.s)?;
+        state.serialize_field("bv", &self.bv)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Rotor3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            S,
+            Bv,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("`s` or `bv`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "s" => Ok(Field::S),
+                            "bv" => Ok(Field::Bv),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Rotor3Visitor;
+
+        impl<'de> Visitor<'de> for Rotor3Visitor {
+            type Value = Rotor3;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct Rotor3")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Rotor3, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let s = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let bv = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                Ok(Rotor3::new(s, bv))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Rotor3, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut s = None;
+                let mut bv = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::S => {
+                            if s.is_some() {
+                                return Err(serde::de::Error::duplicate_field("s"));
+                            }
+                            s = Some(map.next_value()?);
+                        }
+                        Field::Bv => {
+                            if bv.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bv"));
+                            }
+                            bv = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let s = s.ok_or_else(|| serde::de::Error::missing_field("s"))?;
+                let bv = bv.ok_or_else(|| serde::de::Error::missing_field("bv"))?;
+                Ok(Rotor3::new(s, bv))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["s", "bv"];
+
+        deserializer.deserialize_struct("Rotor3", FIELDS, Rotor3Visitor)
+    }
+}
+
+#[cfg(test)]
+mod rotor_serde_tests {
+    use crate::bivec::{Bivec2, Bivec3};
+    use crate::rotor::{Rotor2, Rotor3};
+    use serde_test::{assert_ser_tokens, Token, Deserializer};
+    use serde::Deserialize;
+
+    // This is a workarround for testing despite the fact that `Rotor2` does not implement
+    // PartialEq. The code is copied and paste from the serde_test library.
+    pub fn assert_de_tokens_rotor2<'de>(value: &Rotor2, tokens: &'de [Token])
+    {
+        let mut de = Deserializer::new(tokens);
+        let mut deserialized_val = match Rotor2::deserialize(&mut de) {
+            Ok(v) => {
+                assert_eq!(v.s, value.s);
+                assert_eq!(v.bv.xy, value.bv.xy);
+                v
+            }
+            Err(e) => panic!("tokens failed to deserialize: {}", e),
+        };
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+
+        // Do the same thing for deserialize_in_place. This isn't *great* because a
+        // no-op impl of deserialize_in_place can technically succeed here. Still,
+        // this should catch a lot of junk.
+        let mut de = Deserializer::new(tokens);
+        match Rotor2::deserialize_in_place(&mut de, &mut deserialized_val) {
+            Ok(()) => {
+                assert_eq!(deserialized_val.s, value.s);
+                assert_eq!(deserialized_val.bv.xy, value.bv.xy);
+            }
+            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
+        }
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+    }
+
+    #[test]
+    fn bivec2() {
+        let rotor2 = Rotor2::new(1., Bivec2::new(0.78));
+
+        assert_ser_tokens(
+            &rotor2,
+            &[
+                Token::Struct {
+                    name: "Rotor2",
+                    len: 2,
+                },
+                Token::Str("s"),
+                Token::F32(1.),
+                Token::Str("bv"),
+                Token::Struct {
+                    name: "Bivec2",
+                    len: 1,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens_rotor2(
+            &rotor2,
+            &[
+                Token::Struct {
+                    name: "Rotor2",
+                    len: 2,
+                },
+                Token::Str("s"),
+                Token::F32(1.),
+                Token::Str("bv"),
+                Token::Struct {
+                    name: "Bivec2",
+                    len: 1,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    pub fn assert_de_tokens_rotor3<'de>(value: &Rotor3, tokens: &'de [Token])
+    {
+        let mut de = Deserializer::new(tokens);
+        let mut deserialized_val = match Rotor3::deserialize(&mut de) {
+            Ok(v) => {
+                assert_eq!(v.s, value.s);
+                assert_eq!(v.bv.xy, value.bv.xy);
+                assert_eq!(v.bv.xz, value.bv.xz);
+                assert_eq!(v.bv.yz, value.bv.yz);
+                v
+            }
+            Err(e) => panic!("tokens failed to deserialize: {}", e),
+        };
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+
+        // Do the same thing for deserialize_in_place. This isn't *great* because a
+        // no-op impl of deserialize_in_place can technically succeed here. Still,
+        // this should catch a lot of junk.
+        let mut de = Deserializer::new(tokens);
+        match Rotor3::deserialize_in_place(&mut de, &mut deserialized_val) {
+            Ok(()) => {
+                assert_eq!(deserialized_val.s, value.s);
+                assert_eq!(deserialized_val.bv.xy, value.bv.xy);
+                assert_eq!(deserialized_val.bv.xz, value.bv.xz);
+                assert_eq!(deserialized_val.bv.yz, value.bv.yz);
+            }
+            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
+        }
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+    }
+
+    #[test]
+    fn rotor3() {
+        let rotor3 = Rotor3::new(1., Bivec3::new(0.78, 0.36, 0.63));
+
+        assert_ser_tokens(
+            &rotor3,
+            &[
+                Token::Struct {
+                    name: "Rotor3",
+                    len: 2,
+                },
+                Token::Str("s"),
+                Token::F32(1.),
+                Token::Str("bv"),
+                Token::Struct {
+                    name: "Bivec3",
+                    len: 3,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::Str("xz"),
+                Token::F32(0.36),
+                Token::Str("yz"),
+                Token::F32(0.63),
+                Token::StructEnd,
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens_rotor3(
+            &rotor3,
+            &[
+                Token::Struct {
+                    name: "Rotor3",
+                    len: 2,
+                },
+                Token::Str("s"),
+                Token::F32(1.),
+                Token::Str("bv"),
+                Token::Struct {
+                    name: "Bivec3",
+                    len: 3,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::Str("xz"),
+                Token::F32(0.36),
+                Token::Str("yz"),
+                Token::F32(0.63),
+                Token::StructEnd,
                 Token::StructEnd,
             ],
         );

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -881,3 +881,358 @@ mod mat_serde_tests {
         );
     }
 }
+
+impl Serialize for Bivec2 {
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Bivec2", 1)?;
+        state.serialize_field("xy", &self.xy)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Bivec2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Xy,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("`xy`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "xy" => Ok(Field::Xy),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Bivec2Visitor;
+
+        impl<'de> Visitor<'de> for Bivec2Visitor {
+            type Value = Bivec2;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct Bivec2")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Bivec2, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let xy = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Bivec2::new(xy))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Bivec2, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut xy = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Xy => {
+                            if xy.is_some() {
+                                return Err(serde::de::Error::duplicate_field("xy"));
+                            }
+                            xy = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let xy = xy.ok_or_else(|| serde::de::Error::missing_field("xy"))?;
+                Ok(Bivec2::new(xy))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["xy"];
+
+        deserializer.deserialize_struct("Bivec2", FIELDS, Bivec2Visitor)
+    }
+}
+
+impl Serialize for Bivec3 {
+    fn serialize<T>(&self, serializer: T) -> Result<T::Ok, T::Error>
+    where
+        T: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Bivec3", 3)?;
+        state.serialize_field("xy", &self.xy)?;
+        state.serialize_field("xz", &self.xz)?;
+        state.serialize_field("yz", &self.yz)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Bivec3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Xy,
+            Xz,
+            Yz,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("`xy` or `xz` or `yz`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "xy" => Ok(Field::Xy),
+                            "xz" => Ok(Field::Xz),
+                            "yz" => Ok(Field::Yz),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Bivec3Visitor;
+
+        impl<'de> Visitor<'de> for Bivec3Visitor {
+            type Value = Bivec3;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct Bivec3")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Bivec3, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let xy = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let xz = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                let yz = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
+                Ok(Bivec3::new(xy, xz, yz))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Bivec3, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut xy = None;
+                let mut xz = None;
+                let mut yz = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Xy => {
+                            if xy.is_some() {
+                                return Err(serde::de::Error::duplicate_field("xy"));
+                            }
+                            xy = Some(map.next_value()?);
+                        }
+                        Field::Xz => {
+                            if xz.is_some() {
+                                return Err(serde::de::Error::duplicate_field("xz"));
+                            }
+                            xz = Some(map.next_value()?);
+                        }
+                        Field::Yz => {
+                            if yz.is_some() {
+                                return Err(serde::de::Error::duplicate_field("yz"));
+                            }
+                            yz = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let xy = xy.ok_or_else(|| serde::de::Error::missing_field("xy"))?;
+                let xz = xz.ok_or_else(|| serde::de::Error::missing_field("xz"))?;
+                let yz = yz.ok_or_else(|| serde::de::Error::missing_field("yz"))?;
+                Ok(Bivec3::new(xy, xz, yz))
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["xy", "xz", "yz"];
+
+        deserializer.deserialize_struct("Bivec3", FIELDS, Bivec3Visitor)
+    }
+}
+
+#[cfg(test)]
+mod bivec_serde_tests {
+    use crate::bivec::{Bivec2, Bivec3};
+    use serde_test::{assert_ser_tokens, Token, Deserializer};
+    use serde::Deserialize;
+
+    pub fn assert_de_tokens_bivec2<'de>(value: &Bivec2, tokens: &'de [Token])
+    {
+        let mut de = Deserializer::new(tokens);
+        let mut deserialized_val = match Bivec2::deserialize(&mut de) {
+            Ok(v) => {
+                assert_eq!(v.xy, value.xy);
+                v
+            }
+            Err(e) => panic!("tokens failed to deserialize: {}", e),
+        };
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+
+        // Do the same thing for deserialize_in_place. This isn't *great* because a
+        // no-op impl of deserialize_in_place can technically succeed here. Still,
+        // this should catch a lot of junk.
+        let mut de = Deserializer::new(tokens);
+        match Bivec2::deserialize_in_place(&mut de, &mut deserialized_val) {
+            Ok(()) => {
+                assert_eq!(deserialized_val.xy, value.xy);
+            }
+            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
+        }
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+    }
+
+    #[test]
+    fn bivec2() {
+        let bivec2 = Bivec2::new(0.78);
+
+        assert_ser_tokens(
+            &bivec2,
+            &[
+                Token::Struct {
+                    name: "Bivec2",
+                    len: 1,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens_bivec2(
+            &bivec2,
+            &[
+                Token::Struct {
+                    name: "Bivec2",
+                    len: 1,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    pub fn assert_de_tokens_bivec3<'de>(value: &Bivec3, tokens: &'de [Token])
+    {
+        let mut de = Deserializer::new(tokens);
+        let mut deserialized_val = match Bivec3::deserialize(&mut de) {
+            Ok(v) => {
+                assert_eq!(v.xy, value.xy);
+                assert_eq!(v.xz, value.xz);
+                assert_eq!(v.yz, value.yz);
+                v
+            }
+            Err(e) => panic!("tokens failed to deserialize: {}", e),
+        };
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+
+        // Do the same thing for deserialize_in_place. This isn't *great* because a
+        // no-op impl of deserialize_in_place can technically succeed here. Still,
+        // this should catch a lot of junk.
+        let mut de = Deserializer::new(tokens);
+        match Bivec3::deserialize_in_place(&mut de, &mut deserialized_val) {
+            Ok(()) => {
+                assert_eq!(deserialized_val.xy, value.xy);
+                assert_eq!(deserialized_val.xz, value.xz);
+                assert_eq!(deserialized_val.yz, value.yz);
+            }
+            Err(e) => panic!("tokens failed to deserialize_in_place: {}", e),
+        }
+        if de.remaining() > 0 {
+            panic!("{} remaining tokens", de.remaining());
+        }
+    }
+
+    #[test]
+    fn bivec3() {
+        let bivec3 = Bivec3::new(0.78, 0.36, 0.63);
+
+        assert_ser_tokens(
+            &bivec3,
+            &[
+                Token::Struct {
+                    name: "Bivec3",
+                    len: 3,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::Str("xz"),
+                Token::F32(0.36),
+                Token::Str("yz"),
+                Token::F32(0.63),
+                Token::StructEnd,
+            ],
+        );
+
+        assert_de_tokens_bivec3(
+            &bivec3,
+            &[
+                Token::Struct {
+                    name: "Bivec3",
+                    len: 3,
+                },
+                Token::Str("xy"),
+                Token::F32(0.78),
+                Token::Str("xz"),
+                Token::F32(0.36),
+                Token::Str("yz"),
+                Token::F32(0.63),
+                Token::StructEnd,
+            ],
+        );
+    }
+}

--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -339,6 +339,12 @@ rotor2s!(
     Rotor2x8 => (Mat2x8, Vec2x8, Bivec2x8, f32x8)
 );
 
+impl std::cmp::PartialEq for Rotor2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.s == other.s && self.bv == other.bv
+    }
+}
+
 #[cfg(feature = "f64")]
 rotor2s!(
     DRotor2 => (DMat2, DVec2, DBivec2, f64),
@@ -758,6 +764,12 @@ rotor3s!(
     Rotor3x4 => (Mat3x4, Vec3x4, Bivec3x4, f32x4),
     Rotor3x8 => (Mat3x8, Vec3x8, Bivec3x8, f32x8)
 );
+
+impl std::cmp::PartialEq for Rotor3 {
+    fn eq(&self, other: &Self) -> bool {
+        self.s == other.s && self.bv == other.bv
+    }
+}
 
 #[cfg(feature = "f64")]
 rotor3s!(


### PR DESCRIPTION
Here is a proposition to implement Issue #74 
Since, rotors and bivectors do not implement `PartialEq`, I addapted the methods from serde_test to write the unit tests for deserialization 