### PR TITLE
Fix Rotor2::rotate_vec

### DIFF
--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -190,11 +190,13 @@ macro_rules! rotor2s {
             /// `self` *must* be normalized!
             #[inline]
             pub fn rotate_vec(self, vec: &mut $vt) {
-                let fx = self.s * vec.x + self.bv.xy * vec.y;
-                let fy = self.s * vec.y - (self.bv.xy * vec.x);
+                let s2_minus_bxy2 = self.s * self.s - self.bv.xy * self.bv.xy;
+                let two_s_bxy = $t::splat(2.0) * self.s * self.bv.xy;
 
-                vec.x = self.s * fx - (self.bv.xy * fy);
-                vec.y = self.s * fy + self.bv.xy * fx;
+                *vec = $vt {
+                    x: vec.x * s2_minus_bxy2 - vec.y * two_s_bxy,
+                    y: vec.x * two_s_bxy + vec.y * s2_minus_bxy2
+                }
             }
 
             #[inline]

--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -194,8 +194,8 @@ macro_rules! rotor2s {
                 let two_s_bxy = $t::splat(2.0) * self.s * self.bv.xy;
 
                 *vec = $vt {
-                    x: vec.x * s2_minus_bxy2 - vec.y * two_s_bxy,
-                    y: vec.x * two_s_bxy + vec.y * s2_minus_bxy2
+                    x: vec.x * s2_minus_bxy2 + vec.y * two_s_bxy,
+                    y: vec.x * -two_s_bxy + vec.y * s2_minus_bxy2
                 }
             }
 


### PR DESCRIPTION
Solving #85, I noticed that `Rotor2::into_matrix` seemed to produce correct results so I just used the code that was there. 
You may want to optimize this function in the future, but at least it is correct now.