### PR TITLE
Fix Rotor2::rotate_vec and corresponding derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `Mat4::extract_translation`, `Mat4::extract_rotation` and `Mat4::into_isometry`.
 - Add missing `PartialEq` implementations for all matrices, transformations, vectors, bivectors and rotors, including
   SIMD and `f64` variants
+- Fix `Rotor2::rotate_vec` and corresponding derivation.
 
 ## 0.7.4
 - Add optional bytemuck support

--- a/derivations/rotor2_rotate_vec_derivation.txt
+++ b/derivations/rotor2_rotate_vec_derivation.txt
@@ -34,10 +34,10 @@ ab v ba = (ab v)(S - BxyE1E2)
 =(FxE1 + FyE2)(S - BxyE1E2)
 
 = SFxE1 + SFyE2
-+ BxyFxE1E1E2 + BxyFyE2E1E2
+- BxyFxE1E1E2 - BxyFyE2E1E2
 
-= (SFx - BxyFy)E1
-+ (SFy + BxyFx)E2
+= (SFx + BxyFy)E1
++ (SFy - BxyFx)E2
 
 non-factored version (for conversion from rotor to mat3)
 -------------

--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -193,8 +193,8 @@ macro_rules! rotor2s {
                 let fx = self.s * vec.x + self.bv.xy * vec.y;
                 let fy = self.s * vec.y - (self.bv.xy * vec.x);
 
-                vec.x = self.s * fx - (self.bv.xy * fy);
-                vec.y = self.s * fy + self.bv.xy * fx;
+                vec.x = self.s * fx + self.bv.xy * fy;
+                vec.y = self.s * fy - (self.bv.xy * fx);
             }
 
             #[inline]


### PR DESCRIPTION
This addresses #85. I saw that there was a fix in #86, but it seems more straightforward to do the simple fix per the derivation. A -1 factor was not distributed in the original derivation.