### PR TITLE
Better document undefined behavior in Rotor::from_rotation_between()

### DIFF
--- a/src/rotor.rs
+++ b/src/rotor.rs
@@ -89,6 +89,8 @@ macro_rules! rotor2s {
             }
 
             /// Construct a Rotor that rotates one vector to another.
+            ///
+            /// A rotation between antiparallel vectors is **undefined**!
             #[inline]
             pub fn from_rotation_between(from: $vt, to: $vt) -> Self {
                 Self::new(


### PR DESCRIPTION
I remembered #93 and this is a small warning for undefined behaviour for antiparallel vectors.