### PR TITLE
Generify MulAdd for Vec types

### DIFF
--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -28,7 +28,7 @@ macro_rules! impl_serde_vec2 {
                 enum Field {
                     X,
                     Y,
-                };
+                }
 
                 impl<'de> Deserialize<'de> for Field {
                     fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -144,7 +144,7 @@ macro_rules! impl_serde_vec3 {
                     X,
                     Y,
                     Z,
-                };
+                }
 
                 impl<'de> Deserialize<'de> for Field {
                     fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -274,7 +274,7 @@ macro_rules! impl_serde_vec4 {
                     Y,
                     Z,
                     W,
-                };
+                }
 
                 impl<'de> Deserialize<'de> for Field {
                     fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1071,7 +1071,7 @@ impl<'de> Deserialize<'de> for Bivec2 {
     {
         enum Field {
             Xy,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1169,7 +1169,7 @@ impl<'de> Deserialize<'de> for Bivec3 {
             Xy,
             Xz,
             Yz,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1335,7 +1335,7 @@ impl<'de> Deserialize<'de> for Rotor2 {
         enum Field {
             S,
             Bv,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1443,7 +1443,7 @@ impl<'de> Deserialize<'de> for Rotor3 {
         enum Field {
             S,
             Bv,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1614,7 +1614,7 @@ impl<'de> Deserialize<'de> for Isometry2 {
         enum Field {
             Translation,
             Rotation,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
@@ -1724,7 +1724,7 @@ impl<'de> Deserialize<'de> for Isometry3 {
         enum Field {
             Translation,
             Rotation,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,6 +1,13 @@
-use crate::MulAdd;
 use std::convert::{TryFrom, TryInto};
 use std::ops::*;
+
+pub trait MulAdd<A = Self, B = Self> {
+    /// The resulting type after applying the fused multiply-add.
+    type Output;
+
+    /// Performs the fused multiply-add operation.
+    fn mul_add(self, a: A, b: B) -> Self::Output;
+}
 
 impl MulAdd<u32, u32> for u32 {
     type Output = u32;

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,13 +1,6 @@
+use crate::MulAdd;
 use std::convert::{TryFrom, TryInto};
 use std::ops::*;
-
-pub trait MulAdd<A = Self, B = Self> {
-    /// The resulting type after applying the fused multiply-add.
-    type Output;
-
-    /// Performs the fused multiply-add operation.
-    fn mul_add(self, a: A, b: B) -> Self::Output;
-}
 
 impl MulAdd<u32, u32> for u32 {
     type Output = u32;

--- a/src/int.rs
+++ b/src/int.rs
@@ -121,6 +121,14 @@ macro_rules! IVec2 {
             }
 
             #[inline]
+            pub fn imul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                )
+            }
+
+            #[inline]
             pub fn clamp(&mut self, min: Self, max: Self) {
                 self.x = self.x.max(min.x).min(max.x);
                 self.y = self.y.max(min.y).min(max.y);
@@ -562,6 +570,15 @@ macro_rules! IVec3 {
             }
 
             #[inline]
+            pub fn imul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                    self.z.mul_add(mul, add.z),
+                )
+            }
+
+            #[inline]
             pub fn clamp(&mut self, min: Self, max: Self) {
                 self.x = self.x.max(min.x).min(max.x);
                 self.y = self.y.max(min.y).min(max.y);
@@ -980,6 +997,16 @@ macro_rules! IVec4 {
                     self.y.mul_add(mul.y, add.y),
                     self.z.mul_add(mul.z, add.z),
                     self.w.mul_add(mul.w, add.w),
+                )
+            }
+
+            #[inline]
+            pub fn imul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                    self.z.mul_add(mul, add.z),
+                    self.w.mul_add(mul, add.w),
                 )
             }
 

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -6,11 +6,3 @@ mod vec4;
 pub use vec2::*;
 pub use vec3::*;
 pub use vec4::*;
-
-pub trait MulAdd<A = Self, B = Self> {
-    /// The resulting type after applying the fused multiply-add.
-    type Output;
-
-    /// Performs the fused multiply-add operation.
-    fn mul_add(self, a: A, b: B) -> Self::Output;
-}

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -6,3 +6,11 @@ mod vec4;
 pub use vec2::*;
 pub use vec3::*;
 pub use vec4::*;
+
+pub trait MulAdd<A = Self, B = Self> {
+    /// The resulting type after applying the fused multiply-add.
+    type Output;
+
+    /// Performs the fused multiply-add operation.
+    fn mul_add(self, a: A, b: B) -> Self::Output;
+}

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -150,6 +150,14 @@ macro_rules! vec2s {
             }
 
             #[inline]
+            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul.x, add.x),
+                    self.y.mul_add(mul.y, add.y),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs())
             }
@@ -297,30 +305,6 @@ macro_rules! vec2s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
-            }
-        }
-
-        impl MulAdd for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: Self, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a.x, b.x),
-                    self.y.mul_add(a.y, b.y),
-                )
-            }
-        }
-
-        impl MulAdd<$t> for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: $t, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a, b.x),
-                    self.y.mul_add(a, b.y),
-                )
             }
         }
 

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -150,14 +150,6 @@ macro_rules! vec2s {
             }
 
             #[inline]
-            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
-                $n::new(
-                    self.x.mul_add(mul.x, add.x),
-                    self.y.mul_add(mul.y, add.y),
-                )
-            }
-
-            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs())
             }
@@ -305,6 +297,30 @@ macro_rules! vec2s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
+            }
+        }
+
+        impl MulAdd for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a.x, b.x),
+                    self.y.mul_add(a.y, b.y),
+                )
+            }
+        }
+
+        impl MulAdd<$t> for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: $t, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a, b.x),
+                    self.y.mul_add(a, b.y),
+                )
             }
         }
 

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -158,6 +158,14 @@ macro_rules! vec2s {
             }
 
             #[inline]
+            pub fn fmul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs())
             }

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -195,6 +195,15 @@ macro_rules! vec3s {
             }
 
             #[inline]
+            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul.x, add.x),
+                    self.y.mul_add(mul.y, add.y),
+                    self.z.mul_add(mul.z, add.z),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs())
             }
@@ -347,32 +356,6 @@ macro_rules! vec3s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
-            }
-        }
-
-        impl MulAdd for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: Self, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a.x, b.x),
-                    self.y.mul_add(a.y, b.y),
-                    self.z.mul_add(a.z, b.z),
-                )
-            }
-        }
-
-        impl MulAdd<$t> for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: $t, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a, b.x),
-                    self.y.mul_add(a, b.y),
-                    self.z.mul_add(a, b.z),
-                )
             }
         }
 

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -204,6 +204,15 @@ macro_rules! vec3s {
             }
 
             #[inline]
+            pub fn fmul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                    self.z.mul_add(mul, add.z),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs())
             }

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -195,15 +195,6 @@ macro_rules! vec3s {
             }
 
             #[inline]
-            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
-                $n::new(
-                    self.x.mul_add(mul.x, add.x),
-                    self.y.mul_add(mul.y, add.y),
-                    self.z.mul_add(mul.z, add.z),
-                )
-            }
-
-            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs())
             }
@@ -356,6 +347,32 @@ macro_rules! vec3s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
+            }
+        }
+
+        impl MulAdd for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a.x, b.x),
+                    self.y.mul_add(a.y, b.y),
+                    self.z.mul_add(a.z, b.z),
+                )
+            }
+        }
+
+        impl MulAdd<$t> for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: $t, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a, b.x),
+                    self.y.mul_add(a, b.y),
+                    self.z.mul_add(a, b.z),
+                )
             }
         }
 

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -125,16 +125,6 @@ macro_rules! vec4s {
             }
 
             #[inline]
-            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
-                $n::new(
-                    self.x.mul_add(mul.x, add.x),
-                    self.y.mul_add(mul.y, add.y),
-                    self.z.mul_add(mul.z, add.z),
-                    self.w.mul_add(mul.w, add.w),
-                )
-            }
-
-            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
             }
@@ -292,6 +282,34 @@ macro_rules! vec4s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
+            }
+        }
+
+        impl MulAdd for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a.x, b.x),
+                    self.y.mul_add(a.y, b.y),
+                    self.z.mul_add(a.z, b.z),
+                    self.w.mul_add(a.w, b.w),
+                )
+            }
+        }
+
+        impl MulAdd<$t> for $n {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: $t, b: Self) -> Self::Output {
+                $n::new(
+                    self.x.mul_add(a, b.x),
+                    self.y.mul_add(a, b.y),
+                    self.z.mul_add(a, b.z),
+                    self.w.mul_add(a, b.w),
+                )
             }
         }
 

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -135,6 +135,16 @@ macro_rules! vec4s {
             }
 
             #[inline]
+            pub fn fmul_add(&self, mul: $t, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul, add.x),
+                    self.y.mul_add(mul, add.y),
+                    self.z.mul_add(mul, add.z),
+                    self.w.mul_add(mul, add.w),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
             }

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -125,6 +125,16 @@ macro_rules! vec4s {
             }
 
             #[inline]
+            pub fn mul_add(&self, mul: $n, add: $n) -> Self {
+                $n::new(
+                    self.x.mul_add(mul.x, add.x),
+                    self.y.mul_add(mul.y, add.y),
+                    self.z.mul_add(mul.z, add.z),
+                    self.w.mul_add(mul.w, add.w),
+                )
+            }
+
+            #[inline]
             pub fn abs(&self) -> Self {
                 Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
             }
@@ -282,34 +292,6 @@ macro_rules! vec4s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
-            }
-        }
-
-        impl MulAdd for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: Self, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a.x, b.x),
-                    self.y.mul_add(a.y, b.y),
-                    self.z.mul_add(a.z, b.z),
-                    self.w.mul_add(a.w, b.w),
-                )
-            }
-        }
-
-        impl MulAdd<$t> for $n {
-            type Output = Self;
-
-            #[inline]
-            fn mul_add(self, a: $t, b: Self) -> Self::Output {
-                $n::new(
-                    self.x.mul_add(a, b.x),
-                    self.y.mul_add(a, b.y),
-                    self.z.mul_add(a, b.z),
-                    self.w.mul_add(a, b.w),
-                )
             }
         }
 


### PR DESCRIPTION
I was kinda missing `Vec3::mul_add(&self, a: f32, b: Self)` so I implemented it for all vec types by implementing the trait `MulAdd` for all vec types with `a: Self` and `b: $t`.

I am unsure where to move the trait (was in `int.rs` before), so I put it inside `vec/mod.rs` for now. 