### PR TITLE
Make clippy happy

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -272,10 +272,11 @@ macro_rules! IVec2 {
                 Self::new(comps[0], comps[1])
             }
         }
-        impl Into<[$t; 2]> for $n {
+
+        impl From<$n> for [$t; 2] {
             #[inline]
-            fn into(self) -> [$t; 2] {
-                [self.x, self.y]
+            fn from(v: $n) -> Self {
+                [v.x, v.y]
             }
         }
 
@@ -719,10 +720,11 @@ macro_rules! IVec3 {
                 Self::new(comps[0], comps[1], comps[2])
             }
         }
-        impl Into<[$t; 3]> for $n {
+
+        impl From<$n> for [$t; 3] {
             #[inline]
-            fn into(self) -> [$t; 3] {
-                [self.x, self.y, self.z]
+            fn from(v: $n) -> Self {
+                [v.x, v.y, v.z]
             }
         }
 
@@ -1146,10 +1148,11 @@ macro_rules! IVec4 {
                 Self::new(comps[0], comps[1], comps[2], comps[3])
             }
         }
-        impl Into<[$t; 4]> for $n {
+
+        impl From<$n> for [$t; 4] {
             #[inline]
-            fn into(self) -> [$t; 4] {
-                [self.x, self.y, self.z, self.w]
+            fn from(v: $n) -> Self {
+                [v.x, v.y, v.z, v.w]
             }
         }
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -25,7 +25,7 @@ impl MulAdd<i32, i32> for i32 {
     }
 }
 
-macro_rules! IVec2 {
+macro_rules! ivec2s {
     ($(($n:ident, $v3t:ident, $v4t:ident) => $t:ident),+) => {
         $(
         /// A set of two coordinates which may be interpreted as a vector or point in 2d space.
@@ -444,7 +444,7 @@ macro_rules! IVec2 {
     };
 }
 
-macro_rules! IVec3 {
+macro_rules! ivec3s {
     ($(($v2t:ident, $n:ident, $v4t:ident) => $t:ident),+) => {
         /// A set of three coordinates which may be interpreted as a point or vector in 3d space,
         /// or as a homogeneous 2d vector or point.
@@ -900,7 +900,7 @@ macro_rules! IVec3 {
     }
 }
 
-macro_rules! IVec4 {
+macro_rules! ivec4s {
     ($($n:ident, $v2t:ident, $v3t:ident => $t:ident),+) => {
         /// A set of four coordinates which may be interpreted as a point or vector in 4d space,
         /// or as a homogeneous 3d vector or point.
@@ -1451,14 +1451,14 @@ macro_rules! impl_abs {
     }
 }
 
-IVec2!((UVec2, UVec3, UVec4) => u32);
-IVec2!((IVec2, IVec3, IVec4) => i32);
+ivec2s!((UVec2, UVec3, UVec4) => u32);
+ivec2s!((IVec2, IVec3, IVec4) => i32);
 
-IVec3!((UVec2, UVec3, UVec4) => u32);
-IVec3!((IVec2, IVec3, IVec4) => i32);
+ivec3s!((UVec2, UVec3, UVec4) => u32);
+ivec3s!((IVec2, IVec3, IVec4) => i32);
 
-IVec4!(UVec4, UVec2, UVec3 => u32);
-IVec4!(IVec4, IVec2, IVec3 => i32);
+ivec4s!(UVec4, UVec2, UVec3 => u32);
+ivec4s!(IVec4, IVec2, IVec3 => i32);
 
 impl_abs!(IVec2 => [x, y]);
 impl_abs!(IVec3 => [x, y, z]);

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -308,10 +308,10 @@ macro_rules! vec2s {
             }
         }
 
-        impl Into<[$t; 2]> for $n {
+        impl From<$n> for [$t; 2] {
             #[inline]
-            fn into(self) -> [$t; 2] {
-                [self.x, self.y]
+            fn from(v: $n) -> Self {
+                [v.x, v.y]
             }
         }
 
@@ -620,11 +620,11 @@ macro_rules! impl_wide_vec2s {
     }
 }
 
-impl Into<[Vec2; 4]> for Vec2x4 {
+impl From<Vec2x4> for [Vec2; 4] {
     #[inline]
-    fn into(self) -> [Vec2; 4] {
-        let xs: [f32; 4] = self.x.into();
-        let ys: [f32; 4] = self.y.into();
+    fn from(v: Vec2x4) -> Self {
+        let xs: [f32; 4] = v.x.into();
+        let ys: [f32; 4] = v.y.into();
         [
             Vec2::new(xs[0], ys[0]),
             Vec2::new(xs[1], ys[1]),
@@ -644,11 +644,11 @@ impl From<[Vec2; 4]> for Vec2x4 {
     }
 }
 
-impl Into<[Vec2; 8]> for Vec2x8 {
+impl From<Vec2x8> for [Vec2; 8] {
     #[inline]
-    fn into(self) -> [Vec2; 8] {
-        let xs: [f32; 8] = self.x.into();
-        let ys: [f32; 8] = self.y.into();
+    fn from(v: Vec2x8) -> Self {
+        let xs: [f32; 8] = v.x.into();
+        let ys: [f32; 8] = v.y.into();
         [
             Vec2::new(xs[0], ys[0]),
             Vec2::new(xs[1], ys[1]),
@@ -679,11 +679,11 @@ impl From<[Vec2; 8]> for Vec2x8 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec2; 2]> for DVec2x2 {
+impl From<DVec2x2> for [DVec2; 2] {
     #[inline]
-    fn into(self) -> [DVec2; 2] {
-        let xs: [f64; 2] = self.x.into();
-        let ys: [f64; 2] = self.y.into();
+    fn from(v: DVec2x2) -> Self {
+        let xs: [f64; 2] = v.x.into();
+        let ys: [f64; 2] = v.y.into();
         [DVec2::new(xs[0], ys[0]), DVec2::new(xs[1], ys[1])]
     }
 }
@@ -700,11 +700,11 @@ impl From<[DVec2; 2]> for DVec2x2 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec2; 4]> for DVec2x4 {
+impl From<DVec2x4> for [DVec2; 4] {
     #[inline]
-    fn into(self) -> [DVec2; 4] {
-        let xs: [f64; 4] = self.x.into();
-        let ys: [f64; 4] = self.y.into();
+    fn from(v: DVec2x4) -> Self {
+        let xs: [f64; 4] = v.x.into();
+        let ys: [f64; 4] = v.y.into();
         [
             DVec2::new(xs[0], ys[0]),
             DVec2::new(xs[1], ys[1]),

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -365,10 +365,10 @@ macro_rules! vec3s {
             }
         }
 
-        impl Into<[$t; 3]> for $n {
+        impl From<$n> for [$t; 3] {
             #[inline]
-            fn into(self) -> [$t; 3] {
-                [self.x, self.y, self.z]
+            fn from(v: $n) -> Self {
+                [v.x, v.y, v.z]
             }
         }
 
@@ -705,12 +705,12 @@ macro_rules! impl_wide_vec3s {
     }
 }
 
-impl Into<[Vec3; 4]> for Vec3x4 {
+impl From<Vec3x4> for [Vec3; 4] {
     #[inline]
-    fn into(self) -> [Vec3; 4] {
-        let xs: [f32; 4] = self.x.into();
-        let ys: [f32; 4] = self.y.into();
-        let zs: [f32; 4] = self.z.into();
+    fn from(v: Vec3x4) -> Self {
+        let xs: [f32; 4] = v.x.into();
+        let ys: [f32; 4] = v.y.into();
+        let zs: [f32; 4] = v.z.into();
         [
             Vec3::new(xs[0], ys[0], zs[0]),
             Vec3::new(xs[1], ys[1], zs[1]),
@@ -731,12 +731,12 @@ impl From<[Vec3; 4]> for Vec3x4 {
     }
 }
 
-impl Into<[Vec3; 8]> for Vec3x8 {
+impl From<Vec3x8> for [Vec3; 8] {
     #[inline]
-    fn into(self) -> [Vec3; 8] {
-        let xs: [f32; 8] = self.x.into();
-        let ys: [f32; 8] = self.y.into();
-        let zs: [f32; 8] = self.z.into();
+    fn from(v: Vec3x8) -> [Vec3; 8] {
+        let xs: [f32; 8] = v.x.into();
+        let ys: [f32; 8] = v.y.into();
+        let zs: [f32; 8] = v.z.into();
         [
             Vec3::new(xs[0], ys[0], zs[0]),
             Vec3::new(xs[1], ys[1], zs[1]),
@@ -771,12 +771,12 @@ impl From<[Vec3; 8]> for Vec3x8 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec3; 2]> for DVec3x2 {
+impl From<DVec3x2> for [DVec3; 2] {
     #[inline]
-    fn into(self) -> [DVec3; 2] {
-        let xs: [f64; 2] = self.x.into();
-        let ys: [f64; 2] = self.y.into();
-        let zs: [f64; 2] = self.z.into();
+    fn from(v: DVec3x2) -> Self {
+        let xs: [f64; 2] = v.x.into();
+        let ys: [f64; 2] = v.y.into();
+        let zs: [f64; 2] = v.z.into();
         [
             DVec3::new(xs[0], ys[0], zs[0]),
             DVec3::new(xs[1], ys[1], zs[1]),
@@ -797,12 +797,11 @@ impl From<[DVec3; 2]> for DVec3x2 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec3; 4]> for DVec3x4 {
-    #[inline]
-    fn into(self) -> [DVec3; 4] {
-        let xs: [f64; 4] = self.x.into();
-        let ys: [f64; 4] = self.y.into();
-        let zs: [f64; 4] = self.z.into();
+impl From<DVec3x4> for [DVec3; 4] {
+    fn from(v: DVec3x4) -> Self {
+        let xs: [f64; 4] = v.x.into();
+        let ys: [f64; 4] = v.y.into();
+        let zs: [f64; 4] = v.z.into();
         [
             DVec3::new(xs[0], ys[0], zs[0]),
             DVec3::new(xs[1], ys[1], zs[1]),

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -301,10 +301,10 @@ macro_rules! vec4s {
             }
         }
 
-        impl Into<[$t; 4]> for $n {
+        impl From<$n> for [$t; 4] {
             #[inline]
-            fn into(self) -> [$t; 4] {
-                [self.x, self.y, self.z, self.w]
+            fn from(v: $n) -> Self {
+                [v.x, v.y, v.z, v.w]
             }
         }
 
@@ -619,13 +619,13 @@ macro_rules! impl_wide_vec4s {
     };
 }
 
-impl Into<[Vec4; 4]> for Vec4x4 {
+impl From<Vec4x4> for [Vec4; 4] {
     #[inline]
-    fn into(self) -> [Vec4; 4] {
-        let xs: [f32; 4] = self.x.into();
-        let ys: [f32; 4] = self.y.into();
-        let zs: [f32; 4] = self.z.into();
-        let ws: [f32; 4] = self.w.into();
+    fn from(v: Vec4x4) -> [Vec4; 4] {
+        let xs: [f32; 4] = v.x.into();
+        let ys: [f32; 4] = v.y.into();
+        let zs: [f32; 4] = v.z.into();
+        let ws: [f32; 4] = v.w.into();
         [
             Vec4::new(xs[0], ys[0], zs[0], ws[0]),
             Vec4::new(xs[1], ys[1], zs[1], ws[1]),
@@ -647,13 +647,13 @@ impl From<[Vec4; 4]> for Vec4x4 {
     }
 }
 
-impl Into<[Vec4; 8]> for Vec4x8 {
+impl From<Vec4x8> for [Vec4; 8] {
     #[inline]
-    fn into(self) -> [Vec4; 8] {
-        let xs: [f32; 8] = self.x.into();
-        let ys: [f32; 8] = self.y.into();
-        let zs: [f32; 8] = self.z.into();
-        let ws: [f32; 8] = self.w.into();
+    fn from(v: Vec4x8) -> [Vec4; 8] {
+        let xs: [f32; 8] = v.x.into();
+        let ys: [f32; 8] = v.y.into();
+        let zs: [f32; 8] = v.z.into();
+        let ws: [f32; 8] = v.w.into();
         [
             Vec4::new(xs[0], ys[0], zs[0], ws[0]),
             Vec4::new(xs[1], ys[1], zs[1], ws[1]),
@@ -692,13 +692,13 @@ impl From<[Vec4; 8]> for Vec4x8 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec4; 2]> for DVec4x2 {
+impl From<DVec4x2> for [DVec4; 2] {
     #[inline]
-    fn into(self) -> [DVec4; 2] {
-        let xs: [f64; 2] = self.x.into();
-        let ys: [f64; 2] = self.y.into();
-        let zs: [f64; 2] = self.z.into();
-        let ws: [f64; 2] = self.w.into();
+    fn from(v: DVec4x2) -> Self {
+        let xs: [f64; 2] = v.x.into();
+        let ys: [f64; 2] = v.y.into();
+        let zs: [f64; 2] = v.z.into();
+        let ws: [f64; 2] = v.w.into();
         [
             DVec4::new(xs[0], ys[0], zs[0], ws[0]),
             DVec4::new(xs[1], ys[1], zs[1], ws[1]),
@@ -720,13 +720,13 @@ impl From<[DVec4; 2]> for DVec4x2 {
 }
 
 #[cfg(feature = "f64")]
-impl Into<[DVec4; 4]> for DVec4x4 {
+impl From<DVec4x4> for [DVec4; 4] {
     #[inline]
-    fn into(self) -> [DVec4; 4] {
-        let xs: [f64; 4] = self.x.into();
-        let ys: [f64; 4] = self.y.into();
-        let zs: [f64; 4] = self.z.into();
-        let ws: [f64; 4] = self.w.into();
+    fn from(v: DVec4x4) -> Self {
+        let xs: [f64; 4] = v.x.into();
+        let ys: [f64; 4] = v.y.into();
+        let zs: [f64; 4] = v.z.into();
+        let ws: [f64; 4] = v.w.into();
         [
             DVec4::new(xs[0], ys[0], zs[0], ws[0]),
             DVec4::new(xs[1], ys[1], zs[1], ws[1]),


### PR DESCRIPTION
Following simple changes were made:
- `impl From<>` rather than `impl Into<>` as it gives `into()` for free.
- Rename macros in `int.rs` to keep the rusty snake style and be coherent with the other crate-macros (like `ivec2s` instead of `IVec2`)
  The previous macro name also "clashed" with the vector names themselves.