### PR TITLE
impl TryFrom between vector types (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Implement Serialize and Deserialize for all `UVec`,`IVec`, `DVec`, `DMat` types
   (under `serde`, `int` and `f64` feature flags)
+- Implement conversions between integer and float vectors.
 
 ## 0.8.0
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,7 +1,7 @@
 //! Contains implementations to convert between `UVec`/`IVec` and `Vec`/`DVec`.
 //!
-//! To realize such conversions we make use of [TryFromExt] and [TryIntoExt] to simulate the
-//! behaviour of the official [From] and [Into].
+//! To realize such conversions we make use of crate-private traits `TryFromExt` and `TryIntoExt` to
+//! simulate the behaviour of the official [From] and [Into].
 
 use crate::util::{TryFromExt, TryIntoExt};
 use crate::*;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,0 +1,282 @@
+use crate::*;
+use core::convert::TryFrom;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum FloatErrorKind {
+    NaN,
+    Infinite,
+    PosOverflow,
+    NegOverflow,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct FloatConversionError {
+    pub kind: FloatErrorKind,
+}
+
+impl FloatConversionError {
+    pub const fn nan() -> Self {
+        Self {
+            kind: FloatErrorKind::NaN,
+        }
+    }
+
+    pub const fn infinite() -> Self {
+        Self {
+            kind: FloatErrorKind::Infinite,
+        }
+    }
+
+    pub const fn pos_overflow() -> Self {
+        Self {
+            kind: FloatErrorKind::PosOverflow,
+        }
+    }
+
+    pub const fn neg_overflow() -> Self {
+        Self {
+            kind: FloatErrorKind::NegOverflow,
+        }
+    }
+}
+
+// Not public to not leak outside.
+trait TryFromExt<Source>: Sized {
+    type Error;
+
+    fn try_from(source: Source) -> Result<Self, Self::Error>;
+}
+
+// Not public to not leak outside.
+trait TryIntoExt<Target> {
+    type Error;
+
+    fn try_into(self) -> Result<Target, Self::Error>;
+}
+
+// Generic implementation
+impl<Source, Target, E> TryIntoExt<Target> for Source
+where
+    Target: TryFromExt<Source, Error = E>,
+{
+    type Error = E;
+
+    fn try_into(self) -> Result<Target, Self::Error> {
+        Target::try_from(self)
+    }
+}
+
+macro_rules! impl_try_from_float {
+    ($source:ty => $($target:ident),*) => {$(
+        impl TryFromExt<$source> for $target {
+            type Error = FloatConversionError;
+
+            /// Tries to convert the source to Self in a lossy way, flooring any float value.
+            ///
+            /// # Errors
+            /// * `NaN` - If the float value is `NaN`.
+            /// * `Infinite` - If the float value is infinity or negative infinity.
+            /// * `PosOverflow` - If the float value would be greater than the target max value.
+            /// * `NegOverflow` - If the float value would be less than the target min value.
+            #[inline]
+            fn try_from(source: $source) -> Result<Self, Self::Error> {
+                if source.is_nan() {
+                    return Err(FloatConversionError::nan())
+                }
+                if source.is_infinite() {
+                    return Err(FloatConversionError::infinite())
+                }
+
+                let min = Self::MIN as $source;
+                let max = Self::MAX as $source;
+
+                if source < min {
+                    return Err(FloatConversionError::neg_overflow())
+                }
+                if source > max {
+                    return Err(FloatConversionError::pos_overflow())
+                }
+
+                Ok(source as Self)
+            }
+        }
+    )*}
+}
+
+impl_try_from_float!(f32 => i32, u32);
+impl_try_from_float!(f64 => i32, u32);
+
+macro_rules! impl_try_from_float_vec {
+    ($(($name:ident => $target:ident, [$($var:ident),*])),+) => {
+        $(
+        impl TryFrom<$name> for $target {
+            type Error = FloatConversionError;
+
+            /// Tries to convert the source to Self in a lossy way, flooring any float value.
+            ///
+            /// # Errors
+            /// * `NaN` - If a float value is `NaN`.
+            /// * `NotFinite` - If a float value is infinity or negative infinity.
+            /// * `PosOverflow` - If a float value would be greater than the the self.component max value.
+            /// * `NegOverflow` - If a float value would be less than the self.component min value.
+            #[inline]
+            fn try_from(v: $name) -> Result<Self, Self::Error> {
+                Ok(Self::new($(v.$var.try_into()?,)* ))
+            }
+        }
+        )+
+    }
+}
+
+macro_rules! impl_from_int_vec {
+    ($(($name:ident => $target:ident, $target_type:ident, [$($var:ident),*])),+) => {
+        $(
+        impl From<$name> for $target {
+            #[inline]
+            fn from(v: $name) -> Self {
+                Self::new($(v.$var as $target_type,)*)
+            }
+        }
+        )+
+    };
+}
+
+impl_try_from_float_vec!(
+    (Vec2 => IVec2, [x, y]),
+    (Vec3 => IVec3, [x, y, z]),
+    (Vec4 => IVec4, [x, y, z, w]),
+
+    (Vec2 => UVec2, [x, y]),
+    (Vec3 => UVec3, [x, y, z]),
+    (Vec4 => UVec4, [x, y, z, w])
+);
+
+#[cfg(feature = "f64")]
+impl_try_from_float_vec!(
+    (DVec2 => IVec2, [x, y]),
+    (DVec3 => IVec3, [x, y, z]),
+    (DVec4 => IVec4, [x, y, z, w]),
+
+    (DVec2 => UVec2, [x, y]),
+    (DVec3 => UVec3, [x, y, z]),
+    (DVec4 => UVec4, [x, y, z, w])
+);
+
+impl_from_int_vec!(
+    (IVec2 => Vec2, f32, [x, y]),
+    (IVec3 => Vec3, f32, [x, y, z]),
+    (IVec4 => Vec4, f32, [x, y, z, w]),
+
+    (UVec2 => Vec2, f32, [x, y]),
+    (UVec3 => Vec3, f32, [x, y, z]),
+    (UVec4 => Vec4, f32, [x, y, z, w])
+);
+
+#[cfg(feature = "f64")]
+impl_from_int_vec!(
+    (IVec2 => DVec2, f64, [x, y]),
+    (IVec3 => DVec3, f64, [x, y, z]),
+    (IVec4 => DVec4, f64, [x, y, z, w]),
+
+    (UVec2 => DVec2, f64, [x, y]),
+    (UVec3 => DVec3, f64, [x, y, z]),
+    (UVec4 => DVec4, f64, [x, y, z, w])
+);
+
+
+// tests only for Vec2
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use core::convert::TryFrom;
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_exact() {
+        let vec2 = Vec2::new(1.0, 2.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_ok());
+        assert_eq!(ivec2.ok().unwrap(), IVec2::new(1, 2));
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_floored() {
+        let vec2 = Vec2::new(1.99, 2.99);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_ok());
+        assert_eq!(ivec2.ok().unwrap(), IVec2::new(1, 2));
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_nan() {
+        let vec2 = Vec2::new(f32::NAN, 0.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_err());
+        assert_eq!(ivec2.err().unwrap(), FloatConversionError::nan());
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_infinity() {
+        let vec2 = Vec2::new(f32::INFINITY, 0.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_err());
+        assert_eq!(ivec2.err().unwrap(), FloatConversionError::infinite());
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_neg_infinity() {
+        let vec2 = Vec2::new(f32::NEG_INFINITY, 0.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_err());
+        assert_eq!(ivec2.err().unwrap(), FloatConversionError::infinite());
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_pos_overflow() {
+        let vec2 = Vec2::new(f32::MAX, 0.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_err());
+        assert_eq!(ivec2.err().unwrap(), FloatConversionError::pos_overflow());
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_ivec2_neg_overflow() {
+        let vec2 = Vec2::new(f32::MIN, 0.0);
+        let ivec2 = IVec2::try_from(vec2);
+
+        assert!(ivec2.is_err());
+        assert_eq!(ivec2.err().unwrap(), FloatConversionError::neg_overflow());
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn ivec2_to_vec2() {
+        let ivec2 = IVec2::new(1, 2);
+        let vec2 = Vec2::from(ivec2);
+
+        assert_eq!(vec2, Vec2::new(1.0, 2.0));
+    }
+
+    #[test]
+    #[cfg(feature = "int")]
+    fn vec2_to_uvec2_neg_overflow() {
+        let vec2 = Vec2::new(-1.0, 0.0);
+        let uvec2 = UVec2::try_from(vec2);
+
+
+        assert!(uvec2.is_err());
+        assert_eq!(uvec2.err().unwrap(), FloatConversionError::neg_overflow());
+    }
+}

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -183,7 +183,6 @@ impl_from_int_vec!(
     (UVec4 => DVec4, f64, [x, y, z, w])
 );
 
-
 // tests only for Vec2
 #[cfg(test)]
 mod tests {
@@ -274,7 +273,6 @@ mod tests {
     fn vec2_to_uvec2_neg_overflow() {
         let vec2 = Vec2::new(-1.0, 0.0);
         let uvec2 = UVec2::try_from(vec2);
-
 
         assert!(uvec2.is_err());
         assert_eq!(uvec2.err().unwrap(), FloatConversionError::neg_overflow());

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,3 +1,9 @@
+//! Contains implementations to convert between `UVec`/`IVec` and `Vec`/`DVec`.
+//!
+//! To realize such conversions we make use of [TryFromExt] and [TryIntoExt] to simulate the
+//! behaviour of the official [From] and [Into].
+
+use crate::util::{TryFromExt, TryIntoExt};
 use crate::*;
 use core::convert::TryFrom;
 use std::error::Error;
@@ -25,38 +31,6 @@ impl fmt::Display for FloatConversionError {
 }
 
 impl Error for FloatConversionError {}
-
-/// A simple trait extension to simulate `TryFrom` for types that are not from this crate.
-///
-/// Note: If making public, resolve all `use crate::*` in all files as to not clash with te function
-///       name of `std::convert::TryFrom`
-trait TryFromExt<Source>: Sized {
-    type Error;
-
-    fn try_from(source: Source) -> Result<Self, Self::Error>;
-}
-
-/// A simple trait extension to simulate `TryInto` for types that are not from this crate.
-///
-/// Note: If making public, resolve all `use crate::*` in all files as to not clash with te function
-///       name of `std::convert::TryFrom`
-trait TryIntoExt<Target> {
-    type Error;
-
-    fn try_into(self) -> Result<Target, Self::Error>;
-}
-
-// Generic implementation
-impl<Source, Target, E> TryIntoExt<Target> for Source
-where
-    Target: TryFromExt<Source, Error = E>,
-{
-    type Error = E;
-
-    fn try_into(self) -> Result<Target, Self::Error> {
-        Target::try_from(self)
-    }
-}
 
 macro_rules! impl_try_from_float {
     ($source:ty => $($target:ident),*) => {$(

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,3 +1,4 @@
+use crate::*;
 use std::convert::{TryFrom, TryInto};
 use std::ops::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod util;
 pub(crate) use util::Splat;
 
 pub mod bivec;
+pub mod conversion;
 #[cfg(feature = "int")]
 pub mod int;
 pub mod interp;
@@ -107,10 +108,12 @@ pub use impl_mint::*;
 
 #[cfg(feature = "bytemuck")]
 mod impl_bytemuck;
+
 #[cfg(feature = "bytemuck")]
 pub use impl_bytemuck::*;
 
 pub use bivec::*;
+pub use conversion::*;
 #[cfg(feature = "int")]
 pub use int::*;
 pub use interp::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod util;
 pub(crate) use util::Splat;
 
 pub mod bivec;
+#[cfg(feature = "int")]
 pub mod conversion;
 #[cfg(feature = "int")]
 pub mod int;
@@ -113,6 +114,7 @@ mod impl_bytemuck;
 pub use impl_bytemuck::*;
 
 pub use bivec::*;
+#[cfg(feature = "int")]
 pub use conversion::*;
 #[cfg(feature = "int")]
 pub use int::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -78,3 +78,28 @@ macro_rules! derive_default_identity {
         }
     };
 }
+
+/// A simple trait extension to simulate `TryFrom` for types that are not from this crate.
+pub trait TryFromExt<Source>: Sized {
+    type Error;
+
+    fn try_from(source: Source) -> Result<Self, Self::Error>;
+}
+
+/// A simple trait extension to simulate `TryInto` for types that are not from this crate.
+pub trait TryIntoExt<Target> {
+    type Error;
+
+    fn try_into(self) -> Result<Target, Self::Error>;
+}
+
+impl<Source, Target, E> TryIntoExt<Target> for Source
+where
+    Target: TryFromExt<Source, Error = E>,
+{
+    type Error = E;
+
+    fn try_into(self) -> Result<Target, Self::Error> {
+        Target::try_from(self)
+    }
+}

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -1,6 +1,6 @@
 use std::ops::*;
 
-use crate::util::*;
+use crate::util::EqualsEps;
 use crate::*;
 
 macro_rules! vec2s {

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -1,6 +1,6 @@
 use std::ops::*;
 
-use crate::util::*;
+use crate::util::EqualsEps;
 use crate::*;
 
 macro_rules! vec3s {

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -1,6 +1,6 @@
 use std::ops::*;
 
-use crate::util::*;
+use crate::util::EqualsEps;
 use crate::*;
 
 macro_rules! vec4s {


### PR DESCRIPTION
As conversions between vector types were not possible yet, I made some macros and made those possible. 

As `f32` to `i32`/`u32` may be problematic due to either one of those:
- `f32` is `NaN`, or
- `f32` is infinity or negative infinity, or
- `f32` is greater or less than the maximum/minimum of the target type
I implemented `TryFrom` to give a descriptive error in such cases. 

Implementing `TryFrom` is not possible for types out of the crate, so I used a module-private `TryFromExt` to circumvent it. 

In case of converting from float vectors to int vectors (like `Vec2` -> `IVec2`), any float precision will be lost, resulting in a lossy conversion that is practically "flooring" the float value to the next integer.

I wrote some simple tests for `Vec2` conversions, these could be extended but they showcase the correctness of the above mentioned possible float issues. 

I am open for feedback and possible changes to this pull request.