### PR TITLE
Change bound in map/apply from Fn to FnMut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add methods to scale `Rotor3`
 - Implement `Neg` for all `IVec` types
+- Relax bound in `map` and `apply` from `Fn` to `FnMut`
 
 ## 0.8.1
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -134,8 +134,8 @@ macro_rules! ivec2s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -144,8 +144,8 @@ macro_rules! ivec2s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);
@@ -577,8 +577,8 @@ macro_rules! ivec3s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -588,8 +588,8 @@ macro_rules! ivec3s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);
@@ -1001,8 +1001,8 @@ macro_rules! ivec4s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -1013,8 +1013,8 @@ macro_rules! ivec4s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -176,8 +176,8 @@ macro_rules! vec2s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -186,8 +186,8 @@ macro_rules! vec2s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -224,8 +224,8 @@ macro_rules! vec3s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -235,8 +235,8 @@ macro_rules! vec3s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -156,8 +156,8 @@ macro_rules! vec4s {
             }
 
             #[inline]
-            pub fn map<F>(&self, f: F) -> Self
-                where F: Fn($t) -> $t
+            pub fn map<F>(&self, mut f: F) -> Self
+                where F: FnMut($t) -> $t
             {
                 $n::new(
                     f(self.x),
@@ -168,8 +168,8 @@ macro_rules! vec4s {
             }
 
             #[inline]
-            pub fn apply<F>(&mut self, f: F)
-                where F: Fn($t) -> $t
+            pub fn apply<F>(&mut self, mut f: F)
+                where F: FnMut($t) -> $t
             {
                 self.x = f(self.x);
                 self.y = f(self.y);


### PR DESCRIPTION
This is useful in my case to remap indices in a `UVec3`, but seems generally useful to relax this bound, and matches what the standard library accepts for example in `array::map` or `Iterator::map`.