### PR TITLE
Geometric multiplication for bivectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,6 @@ f64 = []
 int = []
 
 [dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"
 serde_test = "1.0"

--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -643,9 +643,9 @@ bivec3s!(
 
 #[cfg(feature = "f64")]
 bivec3s!(
-    DBivec3 => (DVec3, f64),
-    DBivec3x2 => (DVec3x2, f64x2),
-    DBivec3x4 => (DVec3x4, f64x4)
+    DBivec3 => (DVec3, DRotor3, f64),
+    DBivec3x2 => (DVec3x2, DRotor3x2, f64x2),
+    DBivec3x4 => (DVec3x4, DRotor3x4, f64x4)
 );
 
 #[cfg(test)]

--- a/src/bivec.rs
+++ b/src/bivec.rs
@@ -34,6 +34,7 @@
 //! onto each unit vector.
 use crate::*;
 
+use crate::traits::GeometricMul;
 use crate::util::*;
 
 use std::ops::*;
@@ -291,7 +292,7 @@ macro_rules! bivec2s {
 }
 
 macro_rules! bivec3s {
-    ($($bn:ident => ($vt:ident, $t:ident)),+) => {
+    ($($bn:ident => ($vt:ident, $rt:ident, $t:ident)),+) => {
         $(
         /// A bivector in 3d space.
         ///
@@ -384,6 +385,11 @@ macro_rules! bivec3s {
             }
 
             #[inline]
+            pub fn reverse(&self) -> Self {
+                -*self
+            }
+
+            #[inline]
             pub fn layout() -> alloc::alloc::Layout {
                 alloc::alloc::Layout::from_size_align(std::mem::size_of::<Self>(), std::mem::align_of::<$t>()).unwrap()
             }
@@ -456,6 +462,41 @@ macro_rules! bivec3s {
             fn add(mut self, rhs: $bn) -> Self {
                 self += rhs;
                 self
+            }
+        }
+
+        impl GeometricMul<$bn> for $bn {
+            type Lower = $t;
+            type Upper = $bn;
+            type Full = $rt;
+
+            //       other
+            //     xy  xz  yz
+            // xy  -1 -yz  xz
+            // xz  yz  -1 -xy
+            // yz -xz  xy  -1
+
+            #[inline]
+            fn dot(&self, other: &$bn) -> Self::Lower {
+                (self.xy * -other.xy) + (self.yz * -other.yz) + (self.xz * -other.xz)
+            }
+
+            /// The wedge (aka exterior) product of two bivectors.
+            #[inline]
+            fn wedge(&self, other: &$bn) -> Self::Upper {
+                $bn::new(
+                    (self.xz * -other.yz) + -(self.yz * -other.xz),
+                    (self.xy * other.yz)  + -(-self.yz * -other.xy),
+                    (-self.xy * other.xz) + -(-self.xz * other.xy),
+                )
+            }
+        }
+
+        impl Add<$t> for $bn {
+            type Output = $rt;
+            #[inline]
+            fn add(self, rhs: $t) -> Self::Output {
+                $rt::new(rhs, self)
             }
         }
 
@@ -544,7 +585,7 @@ macro_rules! bivec3s {
             type Output = $bn;
             #[inline]
             fn div(mut self, rhs: $t) -> $bn {
-                self.xy /= rhs;
+                self /= rhs;
                 self
             }
         }
@@ -595,9 +636,9 @@ bivec2s!(
 );
 
 bivec3s!(
-    Bivec3 => (Vec3, f32),
-    Bivec3x4 => (Vec3x4, f32x4),
-    Bivec3x8 => (Vec3x8, f32x8)
+    Bivec3 => (Vec3, Rotor3, f32),
+    Bivec3x4 => (Vec3x4, Rotor3x4, f32x4),
+    Bivec3x8 => (Vec3x8, Rotor3x8, f32x8)
 );
 
 #[cfg(feature = "f64")]
@@ -606,3 +647,29 @@ bivec3s!(
     DBivec3x2 => (DVec3x2, f64x2),
     DBivec3x4 => (DVec3x4, f64x4)
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+
+    #[quickcheck]
+    fn test_bivector_inverse(bv: (f32, f32, f32)) -> TestResult {
+        let bivec = Bivec3::new(bv.0, bv.1, bv.2);
+
+        if bivec.mag().is_nan() || bivec.mag().is_infinite() || bivec.mag() < 0.1e5 {
+            return TestResult::discard();
+        }
+
+        let scale = bivec.gmul(&bivec.reverse());
+        if scale.bv.mag() > 0.1e6 {
+            return TestResult::from_bool(false);
+        }
+        let inverse = bivec.reverse() / scale.s;
+
+        let unit = bivec.gmul(&inverse);
+
+        TestResult::from_bool(unit.bv.mag().abs() < 0.1e6 && (unit.s - 1.0).abs() < 0.1e6)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod interp;
 pub mod mat;
 pub mod projection;
 pub mod rotor;
+pub mod traits;
 pub mod transform;
 pub mod vec;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,26 @@
+use std::ops;
+
+/// Arbitrary geometric product support for a type.
+///
+/// The geometric product is the sum of a grade-lowering (dot) and grade-raising
+/// (wedge) product. These products are quite useful individually, as well as in
+/// concert as the geometric product.
+pub trait GeometricMul<Rhs>
+where
+    // NOTE: we'd ideally prefer to define add in terms of Self::Lower, as
+    // the typical definition is "dot" + "wedge".  Unfortunately, the Lower type
+    // can often be the base type, (e.g. f32), which would make this trait much
+    // less ergonomic.
+    Self::Upper: ops::Add<Self::Lower, Output = Self::Full>,
+{
+    type Upper;
+    type Lower;
+    type Full;
+
+    fn dot(&self, v: &Rhs) -> Self::Lower;
+    fn wedge(&self, v: &Rhs) -> Self::Upper;
+
+    fn gmul(&self, other: &Rhs) -> Self::Full {
+        self.wedge(other) + self.dot(other)
+    }
+}

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -1,5 +1,6 @@
 use std::ops::*;
 
+use crate::traits::GeometricMul;
 use crate::util::EqualsEps;
 use crate::*;
 
@@ -77,7 +78,7 @@ macro_rules! vec3s {
 
             #[inline]
             pub fn dot(&self, other: $n) -> $t {
-                (self.x * other.x) + (self.y * other.y) + (self.z * other.z)
+                GeometricMul::dot(self, &other)
             }
 
             /// The wedge (aka exterior) product of two vectors.
@@ -89,11 +90,7 @@ macro_rules! vec3s {
             /// one which would move `self` closer to `other`.
             #[inline]
             pub fn wedge(&self, other: $n) -> $bn {
-                $bn::new(
-                    (self.x * other.y) - (self.y * other.x),
-                    (self.x * other.z) - (self.z * other.x),
-                    (self.y * other.z) - (self.z * other.y),
-                )
+                GeometricMul::wedge(self, &other)
             }
 
             /// The geometric product of this and another vector, which
@@ -106,7 +103,7 @@ macro_rules! vec3s {
             /// bring `other` towards `self`, and rotate in that direction by twice the angle between them).
             #[inline]
             pub fn geom(&self, other: $n) -> $rn {
-                $rn::new(self.dot(other), self.wedge(other))
+                GeometricMul::gmul(self, &other)
             }
 
             #[inline]
@@ -358,6 +355,33 @@ macro_rules! vec3s {
             #[inline]
             pub fn as_mut_ptr(&mut self) -> *mut $t {
                 self as *mut $n as *mut $t
+            }
+        }
+
+        impl GeometricMul<$n> for $n {
+            type Lower = $t;
+            type Upper = $bn;
+            type Full = $rn;
+
+            #[inline]
+            fn dot(&self, other: &$n) -> $t {
+                (self.x * other.x) + (self.y * other.y) + (self.z * other.z)
+            }
+
+            /// The wedge (aka exterior) product of two vectors.
+            ///
+            /// This operation results in a bivector, which represents
+            /// the plane parallel to the two vectors, and which has a
+            /// 'oriented area' equal to the parallelogram created by extending
+            /// the two vectors, oriented such that the positive direction is the
+            /// one which would move `self` closer to `other`.
+            #[inline]
+            fn wedge(&self, other: &$n) -> $bn {
+                $bn::new(
+                    (self.x * other.y) - (self.y * other.x),
+                    (self.x * other.z) - (self.z * other.x),
+                    (self.y * other.z) - (self.z * other.y),
+                )
             }
         }
 


### PR DESCRIPTION
Add a `GeometricMul` trait for geometric multiplication. Implement it for `vector.gmul(vector)` and `bivector.gmul(bivector)`.

Ideally it'd be implemented across all types, which I may get to. I wanted to double check that this is an agreeable direction first.

Also, fixed an apparent bug in the `Div` `impl` for bivectors. I also think there's a bug in the `dot` method of bivectors, but am less confident on that. I'm working on double checking against literature / other libraries.

The test here uses quickcheck; I've found property-based testing to be nice for "abstract" math libraries. It also demonstrates the utility of defining the geometric product across types. It's theoretically possible to generate a [multiplicative inverse](https://math.stackexchange.com/questions/443555/calculating-the-inverse-of-a-multivector) for anything in G3. Specifically, in rust, all we need is something that implements `GeometricMul` and has a `reverse`.

If this looks good, I'll work on adding a `Reverse` trait next. I can then easily add property tests to check inversion of other types. This may catch further errors, like the `div` issue in bivectors.