### PR TITLE
Implement issue #172

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -424,21 +424,15 @@ macro_rules! ivec2s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 2, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 2, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
         )+
@@ -878,23 +872,15 @@ macro_rules! ivec3s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    2 => &self.z,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 3, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    2 => &mut self.z,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 3, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
         )+
@@ -1312,25 +1298,15 @@ macro_rules! ivec4s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    2 => &self.z,
-                    3 => &self.w,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 4, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    2 => &mut self.z,
-                    3 => &mut self.w,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 4, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
 

--- a/src/vec/vec2.rs
+++ b/src/vec/vec2.rs
@@ -491,21 +491,15 @@ macro_rules! vec2s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 2, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 2, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
 

--- a/src/vec/vec3.rs
+++ b/src/vec/vec3.rs
@@ -549,23 +549,15 @@ macro_rules! vec3s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    2 => &self.z,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 3, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    2 => &mut self.z,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 3, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
 

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -502,6 +502,7 @@ macro_rules! vec4s {
                 self.as_mut_slice().index_mut(index)
             }
         }
+
         impl std::iter::Sum<$n> for $n {
             fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
                 // Kahan summation algorithm

--- a/src/vec/vec4.rs
+++ b/src/vec/vec4.rs
@@ -491,28 +491,17 @@ macro_rules! vec4s {
             type Output = $t;
 
             fn index(&self, index: usize) -> &Self::Output {
-                match index {
-                    0 => &self.x,
-                    1 => &self.y,
-                    2 => &self.z,
-                    3 => &self.w,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 4, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_slice().index(index)
             }
         }
 
         impl IndexMut<usize> for $n {
             fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-                match index {
-                    0 => &mut self.x,
-                    1 => &mut self.y,
-                    2 => &mut self.z,
-                    3 => &mut self.w,
-                    _ => panic!("Invalid for vector of type: {}", std::any::type_name::<$n>()),
-                }
+                assert!(index < 4, "Invalid for vector of type: {}", std::any::type_name::<$n>());
+                self.as_mut_slice().index_mut(index)
             }
         }
-
         impl std::iter::Sum<$n> for $n {
             fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
                 // Kahan summation algorithm


### PR DESCRIPTION
Uses `as_slice` methods instead of `as_array` since `as_array` works differently for integer vectors. This keeps the `Index` and `IndexMut` implementation consistent between all vectors. Codegen is idential. 